### PR TITLE
fix(autofill): handle one-time-code credential list requests

### DIFF
--- a/AutoFillExtension/CredentialProviderCoordinator.swift
+++ b/AutoFillExtension/CredentialProviderCoordinator.swift
@@ -120,6 +120,7 @@ final class CredentialProviderCoordinator {
     var pendingPasskeyRequest: ASPasskeyCredentialRequest?
     var pendingPasskeyRequestParameters: ASPasskeyCredentialRequestParameters?
     var hasPendingOTCRequest = false
+    var hasPendingOTCListRequest = false
     var pendingGeneratePasswordPresentation = false
     var pendingReadOnlyCancellationMessage: String?
     var pendingSavePasswordRequestStorage: Any?
@@ -158,6 +159,25 @@ final class CredentialProviderCoordinator {
         pendingPasskeyRequest = nil
         pendingPasskeyRequestParameters = nil
         hasPendingOTCRequest = false
+        hasPendingOTCListRequest = false
+        clearPendingCreationRequests()
+        didAttemptAutoBiometricUnlock = false
+        pendingUnlock = true
+    }
+
+    // MARK: One-time-code credential list (iOS 18+ / macOS 15+)
+
+    /// Interactive list request for a one-time-code field: the user tapped an
+    /// OTP field and chose this provider from the AutoFill UI, so there is no
+    /// pre-matched credential identity. Unlock, then present matching TOTP
+    /// entries (or the full TOTP list) for manual selection.
+    func prepareOneTimeCodeCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
+        self.serviceIdentifiers = serviceIdentifiers
+        targetRecordIdentifier = nil
+        pendingPasskeyRequest = nil
+        pendingPasskeyRequestParameters = nil
+        hasPendingOTCRequest = false
+        hasPendingOTCListRequest = true
         clearPendingCreationRequests()
         didAttemptAutoBiometricUnlock = false
         pendingUnlock = true
@@ -198,7 +218,9 @@ final class CredentialProviderCoordinator {
         } else if let passwordIdentity = credentialRequest.credentialIdentity as? ASPasswordCredentialIdentity {
             prepareInterfaceToProvideCredential(for: passwordIdentity)
         } else if #available(iOS 18.0, macOS 15.0, *), credentialRequest is ASOneTimeCodeCredentialRequest {
+            serviceIdentifiers = [credentialRequest.credentialIdentity.serviceIdentifier]
             hasPendingOTCRequest = true
+            hasPendingOTCListRequest = false
             targetRecordIdentifier = credentialRequest.credentialIdentity.recordIdentifier
             clearPendingCreationRequests()
             didAttemptAutoBiometricUnlock = false
@@ -310,6 +332,7 @@ final class CredentialProviderCoordinator {
             pendingPasskeyRequest = nil
             pendingPasskeyRequestParameters = nil
             hasPendingOTCRequest = false
+            hasPendingOTCListRequest = false
             clearPendingCreationRequests()
             didAttemptAutoBiometricUnlock = false
             pendingUnlock = false
@@ -323,6 +346,7 @@ final class CredentialProviderCoordinator {
         pendingPasskeyRequest = nil
         pendingPasskeyRequestParameters = nil
         hasPendingOTCRequest = false
+        hasPendingOTCListRequest = false
         pendingGeneratePasswordsRequest = nil
         pendingSavePasswordRequest = savePasswordRequest
         didAttemptAutoBiometricUnlock = false
@@ -344,6 +368,7 @@ final class CredentialProviderCoordinator {
         pendingPasskeyRequest = nil
         pendingPasskeyRequestParameters = nil
         hasPendingOTCRequest = false
+        hasPendingOTCListRequest = false
         pendingSavePasswordRequest = nil
         pendingGeneratePasswordsRequest = generatePasswordsRequest
         didAttemptAutoBiometricUnlock = false
@@ -491,6 +516,12 @@ final class CredentialProviderCoordinator {
         } else if hasPendingOTCRequest {
             if #available(iOS 18.0, macOS 15.0, *) {
                 completeOTCRequestFromPending()
+            }
+        } else if hasPendingOTCListRequest {
+            if #available(iOS 18.0, macOS 15.0, *) {
+                presentOTCMatchesOrFinish()
+            } else {
+                cancelRequest(code: .failed)
             }
         } else {
             presentPasswordMatchesOrFinish()
@@ -915,13 +946,9 @@ final class CredentialProviderCoordinator {
     private func completeOTCRequestFromPending() {
         hasPendingOTCRequest = false
 
-        guard let recordIdentifier = targetRecordIdentifier else {
-            cancelRequest(code: .failed)
-            return
-        }
-
         let totpEntries = parsedEntries.filter(\.hasTOTP)
-        if let entry = totpEntries.first(where: { $0.id.uuidString == recordIdentifier }) {
+        if let recordIdentifier = targetRecordIdentifier,
+           let entry = totpEntries.first(where: { $0.id.uuidString == recordIdentifier }) {
             if entry.isExpired() {
                 presentSearchView(entries: [entry]) { [weak self] selectedEntry in
                     self?.completeOTCRequest(with: selectedEntry)
@@ -930,7 +957,45 @@ final class CredentialProviderCoordinator {
                 completeOTCRequest(with: entry)
             }
         } else {
+            // The identity's record identifier is missing or stale (e.g. the
+            // entry changed since the identity store was last populated).
+            // Fall back to the interactive picker instead of failing.
+            presentOTCMatchesOrFinish()
+        }
+    }
+
+    /// Interactive one-time-code selection: complete immediately on a single
+    /// service match, otherwise present the picker (matches, or all TOTP
+    /// entries with the domain pre-filled). Mirrors `presentPasswordMatchesOrFinish`.
+    @available(iOS 18.0, macOS 15.0, *)
+    func presentOTCMatchesOrFinish() {
+        hasPendingOTCListRequest = false
+
+        let allTOTPEntries = parsedEntries.filter(\.hasTOTP)
+        let totpEntries = allTOTPEntries.filter { !$0.isExpired() }
+
+        guard !allTOTPEntries.isEmpty else {
             cancelRequest(code: .credentialIdentityNotFound)
+            return
+        }
+
+        let matches = CredentialMatcher.matchedEntries(from: totpEntries, for: serviceIdentifiers)
+
+        if matches.count == 1, let entry = matches.first {
+            completeOTCRequest(with: entry)
+            return
+        }
+
+        let searchDomain = serviceIdentifiers.first.flatMap { CredentialMatcher.searchTerm(for: $0) } ?? ""
+
+        if !matches.isEmpty {
+            presentSearchView(entries: matches, initialSearchText: "") { [weak self] entry in
+                self?.completeOTCRequest(with: entry)
+            }
+        } else {
+            presentSearchView(entries: allTOTPEntries, initialSearchText: searchDomain) { [weak self] entry in
+                self?.completeOTCRequest(with: entry)
+            }
         }
     }
 
@@ -971,6 +1036,7 @@ final class CredentialProviderCoordinator {
         pendingPasskeyRequest = nil
         pendingPasskeyRequestParameters = nil
         hasPendingOTCRequest = false
+        hasPendingOTCListRequest = false
         clearPendingCreationRequests()
     }
 

--- a/AutoFillExtension/CredentialProviderViewController.swift
+++ b/AutoFillExtension/CredentialProviderViewController.swift
@@ -42,6 +42,11 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
         coordinator.prepareCredentialList(for: serviceIdentifiers, requestParameters: requestParameters)
     }
 
+    @available(iOS 18.0, *)
+    override func prepareOneTimeCodeCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
+        coordinator.prepareOneTimeCodeCredentialList(for: serviceIdentifiers)
+    }
+
     override func prepareInterfaceToProvideCredential(for credentialRequest: ASCredentialRequest) {
         coordinator.prepareInterfaceToProvideCredential(for: credentialRequest)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix AutoFill showing a blank sheet when picking KeeForge on a one-time-code field (#20): the extension never handled the interactive verification-code list request, so choosing AutoFill → Passwords on a TOTP form did nothing. It now unlocks the vault and fills the code directly when a single entry matches the site, or shows the TOTP entry picker otherwise; a stale QuickType code suggestion also falls back to the picker instead of failing.
+
 - Fix local databases silently opening a stale copy after the file was deleted or replaced in the Files app (#13): iOS bookmarks follow the old file into Recently Deleted, so KeeForge now detects a trashed database file, refuses to open or save to it, and explains how to restore or re-add the current file.
 
 - Add full German localization (iOS app, macOS app, and AutoFill extension): 648 strings across UI, error messages, alerts, and Info.plist usage descriptions, plus a localization test suite that gates translation completeness, format-specifier parity, and app/extension consistency.

--- a/KeeForgeTests/CredentialProviderCoordinatorTests.swift
+++ b/KeeForgeTests/CredentialProviderCoordinatorTests.swift
@@ -182,6 +182,134 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
         assertCleanedUp(coordinator)
     }
 
+    // MARK: - One-time-code list requests (issue #20)
+
+    func test_otcList_singleMatch_completesWithCode() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time-code requests require iOS 18 / macOS 15")
+        }
+
+        let (coordinator, presenter) = makeCoordinator()
+        let sessionKey = SymmetricKey(size: .bits256)
+        let matching = KPEntry(
+            title: "GitHub",
+            url: "https://github.com/login",
+            totpConfig: TOTPConfig(
+                secret: try EncryptedValue.encrypt("JBSWY3DPEHPK3PXP", using: sessionKey)
+            )
+        )
+        let other = KPEntry(
+            title: "Example",
+            url: "https://example.com",
+            totpConfig: TOTPConfig(
+                secret: try EncryptedValue.encrypt("JBSWY3DPEHPK3PXP", using: sessionKey)
+            )
+        )
+
+        coordinator.prepareOneTimeCodeCredentialList(for: [githubServiceIdentifier()])
+        XCTAssertTrue(coordinator.hasPendingOTCListRequest, "List request must be recorded for post-unlock handling")
+        seedUnlockedVaultState(coordinator, entries: [matching, other], sessionKey: sessionKey)
+
+        coordinator.presentOTCMatchesOrFinish()
+
+        let code = try XCTUnwrap(presenter.completedOneTimeCode, "A single service match should complete without a picker")
+        XCTAssertEqual(code.count, 6)
+        XCTAssertNotEqual(code, "------")
+        assertCleanedUp(coordinator)
+    }
+
+    func test_otcList_multipleMatches_presentsPickerAndCompletesOnSelection() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time-code requests require iOS 18 / macOS 15")
+        }
+
+        let (coordinator, presenter) = makeCoordinator()
+        let sessionKey = SymmetricKey(size: .bits256)
+        let entries = try ["GitHub", "GitHub Work"].map { title in
+            KPEntry(
+                title: title,
+                url: "https://github.com/login",
+                totpConfig: TOTPConfig(
+                    secret: try EncryptedValue.encrypt("JBSWY3DPEHPK3PXP", using: sessionKey)
+                )
+            )
+        }
+
+        coordinator.prepareOneTimeCodeCredentialList(for: [githubServiceIdentifier()])
+        seedUnlockedVaultState(coordinator, entries: entries, sessionKey: sessionKey)
+
+        coordinator.presentOTCMatchesOrFinish()
+
+        let searchView = try XCTUnwrap(presenter.searchView, "Multiple matches should present the picker")
+        XCTAssertEqual(searchView.entries.count, 2)
+        XCTAssertEqual(searchView.initialSearchText, "")
+
+        searchView.onSelect(entries[0])
+
+        let code = try XCTUnwrap(presenter.completedOneTimeCode)
+        XCTAssertEqual(code.count, 6)
+        assertCleanedUp(coordinator)
+    }
+
+    func test_otcList_noMatches_presentsAllTOTPEntriesWithDomainPrefilled() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time-code requests require iOS 18 / macOS 15")
+        }
+
+        let (coordinator, presenter) = makeCoordinator()
+        let sessionKey = SymmetricKey(size: .bits256)
+        let totpEntry = KPEntry(
+            title: "Example",
+            url: "https://example.com",
+            totpConfig: TOTPConfig(
+                secret: try EncryptedValue.encrypt("JBSWY3DPEHPK3PXP", using: sessionKey)
+            )
+        )
+        let passwordOnlyEntry = KPEntry(
+            title: "No TOTP",
+            username: "user",
+            password: try EncryptedValue.encrypt("hunter2", using: sessionKey),
+            url: "https://github.com/login"
+        )
+
+        coordinator.prepareOneTimeCodeCredentialList(for: [githubServiceIdentifier()])
+        seedUnlockedVaultState(coordinator, entries: [totpEntry, passwordOnlyEntry], sessionKey: sessionKey)
+
+        coordinator.presentOTCMatchesOrFinish()
+
+        let searchView = try XCTUnwrap(presenter.searchView, "No matches should still present the full TOTP list")
+        XCTAssertEqual(searchView.entries.map(\.title), ["Example"], "Only TOTP-capable entries belong in the OTC picker")
+        XCTAssertEqual(searchView.initialSearchText, "github.com")
+
+        searchView.onSelect(totpEntry)
+
+        XCTAssertNotNil(presenter.completedOneTimeCode)
+        assertCleanedUp(coordinator)
+    }
+
+    func test_otcList_noTOTPEntries_cancelsWithCredentialIdentityNotFound() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time-code requests require iOS 18 / macOS 15")
+        }
+
+        let (coordinator, presenter) = makeCoordinator()
+        let sessionKey = SymmetricKey(size: .bits256)
+        let passwordOnlyEntry = KPEntry(
+            title: "No TOTP",
+            username: "user",
+            password: try EncryptedValue.encrypt("hunter2", using: sessionKey),
+            url: "https://github.com/login"
+        )
+
+        coordinator.prepareOneTimeCodeCredentialList(for: [githubServiceIdentifier()])
+        seedUnlockedVaultState(coordinator, entries: [passwordOnlyEntry], sessionKey: sessionKey)
+
+        coordinator.presentOTCMatchesOrFinish()
+
+        XCTAssertEqual(presenter.cancelledError?.code, .credentialIdentityNotFound)
+        assertCleanedUp(coordinator)
+    }
+
     func test_cleanup_runsOnPasskeyAssertionCompletion() throws {
         let (coordinator, presenter) = makeCoordinator()
         let sessionKey = SymmetricKey(size: .bits256)
@@ -382,6 +510,7 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
         XCTAssertNil(coordinator.pendingPasskeyRequest, "pending passkey request must be cleared", file: file, line: line)
         XCTAssertNil(coordinator.pendingPasskeyRequestParameters, "pending passkey parameters must be cleared", file: file, line: line)
         XCTAssertFalse(coordinator.hasPendingOTCRequest, "pending OTC flag must be cleared", file: file, line: line)
+        XCTAssertFalse(coordinator.hasPendingOTCListRequest, "pending OTC list flag must be cleared", file: file, line: line)
         XCTAssertNil(coordinator.pendingReadOnlyCancellationMessage, "pending read-only message must be cleared", file: file, line: line)
         XCTAssertNil(coordinator.pendingSavePasswordRequestStorage, "pending save request must be cleared", file: file, line: line)
         XCTAssertNil(coordinator.pendingGeneratePasswordsRequestStorage, "pending generate request must be cleared", file: file, line: line)


### PR DESCRIPTION
Fixes #20

## Problem

The extension declares `ProvidesOneTimeCodes`, so iOS offers KeeForge on verification-code fields — but the iOS shell never overrode `prepareOneTimeCodeCredentialList(for:)`, the iOS 18+ entry point invoked when the user taps a TOTP field and picks KeeForge from the AutoFill sheet. The base class's no-op ran: no UI, no completion, just the blank sheet in the issue's screenshot.

The only working TOTP path was a QuickType suggestion backed by a registered one-time-code identity, and even that cancelled the request when the identity's record identifier was stale.

## Changes

- **`CredentialProviderViewController.swift`**: forward `prepareOneTimeCodeCredentialList(for:)` to the coordinator (`@available(iOS 18.0, *)`).
- **`CredentialProviderCoordinator.swift`**: new `prepareOneTimeCodeCredentialList` entry point and a `presentOTCMatchesOrFinish()` flow mirroring the password list flow — after unlock it fills the code immediately when exactly one TOTP entry matches the site, presents the entry picker for multiple matches, or shows all TOTP entries with the domain pre-filled when nothing matches. Identity-backed OTC requests now also record the request's service identifier and fall back to this picker on a missing/stale record identifier instead of cancelling. Every completion path still funnels through `cleanup()`.
- **`KeeForgeTests/CredentialProviderCoordinatorTests.swift`**: four new tests (single-match fill, multi-match picker, no-match fallback list with pre-filled domain, no-TOTP-entries cancel) plus teardown assertion coverage for the new state flag.
- **`CHANGELOG.md`**: entry under Unreleased.

## Notes

- Developed in an environment without Xcode, so the suite hasn't been run here. Please run `-only-testing:KeeForgeTests/CredentialProviderCoordinatorTests` and ideally verify on-device that picking KeeForge on a TOTP field now unlocks and fills.
- The issue's expected behavior 4.1 (auto-copy TOTP to clipboard after a password fill, like 1Password/Bitwarden) is a separate opt-in feature and intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZSwy1qCmhotyRun8UKNKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZSwy1qCmhotyRun8UKNKc)_