### PR TITLE
test(crypto): add RFC 8439 known-answer vectors for inner-stream ChaCha20

### DIFF
--- a/KeeForge.xcodeproj/project.pbxproj
+++ b/KeeForge.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		7725E1109FAED809C9923CFD /* test-v1.key in Resources */ = {isa = PBXBuildFile; fileRef = 4C350259754DFA5D42D782A7 /* test-v1.key */; };
 		775F9BA8EFAEF1F361AFF6BB /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF7A2480DF3853AFF0AF02B /* Entry.swift */; };
 		776466A679F17BCB1E7E3762 /* TwofishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D923EB4B018FB500295E74 /* TwofishTests.swift */; };
+		665A47FBEF96CB7164341DA2 /* ChaCha20Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87477A6BC8CBFED1E9B1A05 /* ChaCha20Tests.swift */; };
 		7773C42734CD4B651C8EF7B7 /* CredentialMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8B2C6F3F5C2509AC462D87 /* CredentialMatcher.swift */; };
 		77E08F862D8F74AE6898370A /* PasswordDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E0212432C502CF3BCFAB93 /* PasswordDisplay.swift */; };
 		781E15E8E17D86DAEA0CA906 /* PasswordDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E0212432C502CF3BCFAB93 /* PasswordDisplay.swift */; };
@@ -446,6 +447,7 @@
 		D7EA74FAC284CF307F6BA24C /* KeyFileProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0418ADF1FDFF66CD471789 /* KeyFileProcessorTests.swift */; };
 		D867DA976DABC1214D9E7066 /* CloudSyncModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EFE96A1D98D220EA6E3E53 /* CloudSyncModels.swift */; };
 		D8AF5DE599A6ADBBC0E7FDF6 /* TwofishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D923EB4B018FB500295E74 /* TwofishTests.swift */; };
+		F4DEC106E48CAEB529336F4F /* ChaCha20Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87477A6BC8CBFED1E9B1A05 /* ChaCha20Tests.swift */; };
 		D8E93E95B6B7E206F55F993E /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B531885B533C74F391440B2B /* LocalizationTests.swift */; };
 		D9BA1A855C5E14A6B9D0FF3C /* SecureRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F135327240ED1387C8003A4 /* SecureRandom.swift */; };
 		DA2774F54BE4C3E24D709359 /* PasswordInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40669422B3751841943019C /* PasswordInputRow.swift */; };
@@ -784,6 +786,7 @@
 		C00AB8532846AD90E91C72B2 /* WebDAVConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVConnectView.swift; sourceTree = "<group>"; };
 		C0766AA20A206C0DEE4B732D /* WebDAVCloudProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVCloudProvider.swift; sourceTree = "<group>"; };
 		C0D923EB4B018FB500295E74 /* TwofishTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwofishTests.swift; sourceTree = "<group>"; };
+		B87477A6BC8CBFED1E9B1A05 /* ChaCha20Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaCha20Tests.swift; sourceTree = "<group>"; };
 		C243B2746CDA396F76E052B6 /* KDBXWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDBXWriter.swift; sourceTree = "<group>"; };
 		C28D00833DC5188EEBB34BE9 /* password-keyfile.kdbx */ = {isa = PBXFileReference; path = "password-keyfile.kdbx"; sourceTree = "<group>"; };
 		C2C726CD862BFFCE77228AAD /* UnlockFlowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockFlowUITests.swift; sourceTree = "<group>"; };
@@ -1277,6 +1280,7 @@
 				04A1400E503A230DF2633686 /* TOTPGeneratorTests.swift */,
 				A3660A7394A4B715ECCC64FF /* TOTPViewModelTests.swift */,
 				C0D923EB4B018FB500295E74 /* TwofishTests.swift */,
+				B87477A6BC8CBFED1E9B1A05 /* ChaCha20Tests.swift */,
 				4C745531E956F6B374FC606F /* VerifyKeyfileTests.swift */,
 				B16B7DC25FE8C1CEE117E7FD /* WebDAVClientTests.swift */,
 				D9B34D490C64CC4D568F1384 /* WebDAVCloudProviderTests.swift */,
@@ -1851,6 +1855,7 @@
 				C2665CB62D2BC39D58B72B0C /* TOTPViewModelTests.swift in Sources */,
 				E3CE91C7FA62C3CE81BE0228 /* TestDatabaseSupport.swift in Sources */,
 				776466A679F17BCB1E7E3762 /* TwofishTests.swift in Sources */,
+				665A47FBEF96CB7164341DA2 /* ChaCha20Tests.swift in Sources */,
 				F567FC26EF31BE0C9CD70BC0 /* VerifyKeyfileTests.swift in Sources */,
 				711E28602252C35A2481E769 /* WebDAVClientTests.swift in Sources */,
 				0DFF7C87E66AB78D968C59C0 /* WebDAVCloudProviderTests.swift in Sources */,
@@ -2171,6 +2176,7 @@
 				C2AD719517065CB7FC2BEB4F /* TOTPViewModelTests.swift in Sources */,
 				C025799D1EEC680AC16E22B6 /* TestDatabaseSupport.swift in Sources */,
 				D8AF5DE599A6ADBBC0E7FDF6 /* TwofishTests.swift in Sources */,
+				F4DEC106E48CAEB529336F4F /* ChaCha20Tests.swift in Sources */,
 				DC071F7A487715323727D9A4 /* VerifyKeyfileTests.swift in Sources */,
 				6560E50E8DAC0256CE4FD7D6 /* WebDAVClientTests.swift in Sources */,
 				AB2EDD795CFABEA25AE6EE4A /* WebDAVCloudProviderTests.swift in Sources */,

--- a/KeeForgeTests/ChaCha20Tests.swift
+++ b/KeeForgeTests/ChaCha20Tests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+@testable import KeeForge
+
+/// Known-answer tests for the hand-rolled inner-stream ChaCha20 in `KDBXCrypto`.
+///
+/// The existing suite exercises ChaCha20 only through round-trip and synthetic
+/// fixtures, which cannot detect a subtly-wrong keystream (encrypt/decrypt cancel
+/// out even when the state setup or quarter-rounds are off). These vectors pin the
+/// output to the ChaCha20 reference in RFC 8439, independent of this codebase.
+final class ChaCha20Tests: XCTestCase {
+
+    /// RFC 8439, Appendix A.1, Test Vector #1: all-zero key and nonce, block
+    /// counter 0 (which is where `KDBXCrypto` starts its counter). ChaCha20 is
+    /// XOR-based, so encrypting 64 zero bytes yields the raw keystream block.
+    func test_chacha20_matchesRFC8439_appendixA1_vector1() throws {
+        let key = Data(repeating: 0, count: 32)
+        let nonce = Data(repeating: 0, count: 12)
+        let zeros = Data(repeating: 0, count: 64)
+
+        let expectedKeystream = Data([
+            0x76, 0xb8, 0xe0, 0xad, 0xa0, 0xf1, 0x3d, 0x90,
+            0x40, 0x5d, 0x6a, 0xe5, 0x53, 0x86, 0xbd, 0x28,
+            0xbd, 0xd2, 0x19, 0xb8, 0xa0, 0x8d, 0xed, 0x1a,
+            0xa8, 0x36, 0xef, 0xcc, 0x8b, 0x77, 0x0d, 0xc7,
+            0xda, 0x41, 0x59, 0x7c, 0x51, 0x57, 0x48, 0x8d,
+            0x77, 0x24, 0xe0, 0x3f, 0xb8, 0xd8, 0x4a, 0x37,
+            0x6a, 0x43, 0xb8, 0xf4, 0x15, 0x18, 0xa1, 0x1c,
+            0xc3, 0x87, 0xb6, 0x69, 0xb2, 0xee, 0x65, 0x86,
+        ])
+
+        let keystream = try KDBXCrypto.encryptChaCha20(data: zeros, key: key, nonce: nonce)
+        XCTAssertEqual(keystream, expectedKeystream)
+    }
+
+    /// The decrypt entry point must reproduce the same keystream (it is XOR-based),
+    /// so decrypting the reference keystream recovers the original zero bytes.
+    func test_chacha20_decryptRecoversPlaintext_forRFC8439Vector1() throws {
+        let key = Data(repeating: 0, count: 32)
+        let nonce = Data(repeating: 0, count: 12)
+        let zeros = Data(repeating: 0, count: 64)
+
+        let keystream = try KDBXCrypto.encryptChaCha20(data: zeros, key: key, nonce: nonce)
+        let recovered = try KDBXCrypto.decryptChaCha20(data: keystream, key: key, nonce: nonce)
+        XCTAssertEqual(recovered, zeros)
+    }
+
+    /// A multi-block payload must advance the block counter correctly, so the
+    /// first 64 bytes still match the Test Vector #1 keystream when a longer
+    /// buffer is encrypted in one call.
+    func test_chacha20_firstBlockMatches_whenEncryptingMultipleBlocks() throws {
+        let key = Data(repeating: 0, count: 32)
+        let nonce = Data(repeating: 0, count: 12)
+        let zeros = Data(repeating: 0, count: 160) // 2.5 blocks
+
+        let keystream = try KDBXCrypto.encryptChaCha20(data: zeros, key: key, nonce: nonce)
+
+        let expectedFirstBlock = Data([
+            0x76, 0xb8, 0xe0, 0xad, 0xa0, 0xf1, 0x3d, 0x90,
+            0x40, 0x5d, 0x6a, 0xe5, 0x53, 0x86, 0xbd, 0x28,
+            0xbd, 0xd2, 0x19, 0xb8, 0xa0, 0x8d, 0xed, 0x1a,
+            0xa8, 0x36, 0xef, 0xcc, 0x8b, 0x77, 0x0d, 0xc7,
+            0xda, 0x41, 0x59, 0x7c, 0x51, 0x57, 0x48, 0x8d,
+            0x77, 0x24, 0xe0, 0x3f, 0xb8, 0xd8, 0x4a, 0x37,
+            0x6a, 0x43, 0xb8, 0xf4, 0x15, 0x18, 0xa1, 0x1c,
+            0xc3, 0x87, 0xb6, 0x69, 0xb2, 0xee, 0x65, 0x86,
+        ])
+
+        XCTAssertEqual(Data(keystream.prefix(64)), expectedFirstBlock)
+        XCTAssertEqual(keystream.count, 160)
+    }
+}


### PR DESCRIPTION
Closes #25.

Adds RFC 8439 Appendix A.1 Test Vector #1 as a known-answer test for the hand-rolled inner-stream ChaCha20, plus a decrypt-symmetry check and a multi-block first-block check. Also registers the new file in both test targets (the project uses explicit membership, not synchronized groups, so it wouldn't compile in otherwise).

Verified locally: `Executed 3 tests, with 0 failures` on the iOS simulator. The file name and test naming are just my picks let me know if you'd prefer a different convention.
