### PR TITLE
fix(security): keep ATS enforced for first-party hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ TODO before the first macOS release:
 
 ## Unreleased
 
+- App Transport Security now stays enforced for the app's own fixed hosts — favicons (DuckDuckGo), feedback, and the Dropbox/Microsoft cloud endpoints — via per-domain exceptions. The global arbitrary-loads allowance remains only for user-entered WebDAV servers, many of which still require legacy TLS ciphers that ATS otherwise rejects.
 - Choose which databases appear in AutoFill, get suggestions from all of them at once, and clear AutoFill suggestions in Settings.
 - Switch between databases inside the AutoFill panel.
 - Saving a database now regenerates the file header's random material — master seed, encryption IV, inner stream key, and KDF salt — on every save, matching KeePass 2.x and KeePassXC. KDF cost settings (Argon2 iterations/memory/parallelism, AES-KDF rounds) are preserved, and saved files remain fully compatible with other KeePass clients. Thanks to Kinglike1337 for the contribution.

--- a/KeeForge/Info.plist
+++ b/KeeForge/Info.plist
@@ -100,6 +100,46 @@
 		-->
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+		<!--
+		First-party hosts the app controls are modern HTTPS, so ATS stays
+		enforced for them via per-domain exceptions. Listing a domain here
+		re-applies ATS to it (forward secrecy, TLS 1.2, no cleartext HTTP)
+		while everything unlisted still falls under NSAllowsArbitraryLoads
+		above, so user-entered WebDAV hosts are unaffected.
+		-->
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>duckduckgo.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>keeforge.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>dropbox.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>dropboxapi.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>microsoft.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>microsoftonline.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>SKIncludeConsumableInAppPurchaseHistory</key>
 	<true/>

--- a/KeeForgeMac/Info.plist
+++ b/KeeForgeMac/Info.plist
@@ -86,6 +86,46 @@
 		-->
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+		<!--
+		First-party hosts the app controls are modern HTTPS, so ATS stays
+		enforced for them via per-domain exceptions. Listing a domain here
+		re-applies ATS to it (forward secrecy, TLS 1.2, no cleartext HTTP)
+		while everything unlisted still falls under NSAllowsArbitraryLoads
+		above, so user-entered WebDAV hosts are unaffected.
+		-->
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>duckduckgo.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>keeforge.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>dropbox.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>dropboxapi.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>microsoft.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>microsoftonline.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>SKIncludeConsumableInAppPurchaseHistory</key>
 	<true/>


### PR DESCRIPTION
Closes #26.

Keeps `NSAllowsArbitraryLoads` on for user-entered WebDAV servers, but adds `NSExceptionDomains` for the app's own fixed hosts — `duckduckgo.com` (favicons), `keeforge.com` (feedback), and the Dropbox/Microsoft cloud endpoints — so ATS stays enforced for them. Anything not listed still falls under arbitrary loads, so the user-entered WebDAV path is unaffected. Includes a CHANGELOG entry.

Both `Info.plist`s pass `plutil -lint`, the app builds, and the built app's processed `Info.plist` contains the exceptions as expected.

<sub>Note: this branch briefly carried a second commit raising the timeouts in `testSaveUnderNSFileCoordinatorDoesNotDeadlockWhenOtherCoordinatorActive`, which was failing the CI gate on unrelated PRs. You've since fixed that on `main` (same 5s/30s bounds), so I dropped my commit — this PR is ATS-only again and merges cleanly.</sub>
