### PR TITLE
Remove duplicate security-vulnerability contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,3 @@
+# GitHub adds a "Report a security vulnerability" card automatically
+# because private vulnerability reporting is enabled — no contact_links needed.
 blank_issues_enabled: true
-contact_links:
-  - name: Security vulnerability
-    url: https://github.com/KeeForge/KeeForge/security/advisories/new
-    about: Please report security vulnerabilities privately via a security advisory, not a public issue.


### PR DESCRIPTION
GitHub already shows a built-in "Report a security vulnerability" card on the new-issue chooser when private vulnerability reporting is enabled, so the `contact_links` entry in `.github/ISSUE_TEMPLATE/config.yml` produced a duplicate card. Remove it and keep `blank_issues_enabled: true` explicit.