### PR TITLE
fix(autofill): handle late interactive requests

### DIFF
--- a/AutoFillExtension/CredentialProviderCoordinator.swift
+++ b/AutoFillExtension/CredentialProviderCoordinator.swift
@@ -42,6 +42,10 @@ struct CredentialProviderDatabaseSwitcherContext {
 /// `cleanup()` before asking the shell to complete or cancel the request.
 @MainActor
 protocol CredentialProviderPresenting: AnyObject {
+    /// Whether the shell's view hierarchy is currently on screen and can
+    /// safely present interactive UI.
+    var isPresentationActive: Bool { get }
+
     /// Whether the shell is currently showing modal content. Used to avoid
     /// double-presenting the unlock prompt (mirrors `presentedViewController != nil`).
     var isDisplayingContent: Bool { get }
@@ -205,6 +209,7 @@ final class CredentialProviderCoordinator {
         clearPendingCreationRequests()
         didAttemptAutoBiometricUnlock = false
         pendingUnlock = true
+        activatePresentationIfPossible()
     }
 
     // MARK: One-time-code credential list (iOS 18+ / macOS 15+)
@@ -223,6 +228,7 @@ final class CredentialProviderCoordinator {
         clearPendingCreationRequests()
         didAttemptAutoBiometricUnlock = false
         pendingUnlock = true
+        activatePresentationIfPossible()
     }
 
     func prepareInterfaceToProvideCredential(for credentialIdentity: ASPasswordCredentialIdentity) {
@@ -235,6 +241,7 @@ final class CredentialProviderCoordinator {
         // Delay unlock until the shell is fully presented,
         // otherwise biometric auth fails with "not interactive".
         pendingUnlock = true
+        activatePresentationIfPossible()
     }
 
     // MARK: Passkey credential request (iOS 17+)
@@ -247,6 +254,7 @@ final class CredentialProviderCoordinator {
         clearPendingCreationRequests()
         didAttemptAutoBiometricUnlock = false
         pendingUnlock = true
+        activatePresentationIfPossible()
     }
 
     func prepareInterfaceToProvideCredential(for credentialRequest: ASCredentialRequest) {
@@ -257,6 +265,7 @@ final class CredentialProviderCoordinator {
             clearPendingCreationRequests()
             didAttemptAutoBiometricUnlock = false
             pendingUnlock = true
+            activatePresentationIfPossible()
         } else if let passwordIdentity = credentialRequest.credentialIdentity as? ASPasswordCredentialIdentity {
             prepareInterfaceToProvideCredential(for: passwordIdentity)
         } else if #available(iOS 18.0, macOS 15.0, *), credentialRequest is ASOneTimeCodeCredentialRequest {
@@ -267,6 +276,7 @@ final class CredentialProviderCoordinator {
             clearPendingCreationRequests()
             didAttemptAutoBiometricUnlock = false
             pendingUnlock = true
+            activatePresentationIfPossible()
         } else {
             cancelRequest(code: .failed)
         }
@@ -284,7 +294,7 @@ final class CredentialProviderCoordinator {
         }
     }
 
-    /// Called by the shell once its view hierarchy is on screen (viewWillAppear).
+    /// Called by the shell once its view hierarchy is on screen.
     func presentationDidBecomeActive() {
         if pendingUnlock {
             pendingUnlock = false
@@ -303,6 +313,17 @@ final class CredentialProviderCoordinator {
                 presentGeneratePasswordPrompt(for: pendingGeneratePasswordsRequest)
             }
             #endif
+        }
+    }
+
+    private func activatePresentationIfPossible() {
+        guard presenter?.isPresentationActive == true else { return }
+
+        // Defer until the request callback has returned before asking UIKit or
+        // AppKit to present another controller or alert.
+        Task { @MainActor [weak self] in
+            guard let self, presenter?.isPresentationActive == true else { return }
+            presentationDidBecomeActive()
         }
     }
 
@@ -393,6 +414,7 @@ final class CredentialProviderCoordinator {
             didAttemptAutoBiometricUnlock = false
             pendingUnlock = false
             pendingNoEnabledDatabasesPresentation = true
+            activatePresentationIfPossible()
             return
         }
 
@@ -408,6 +430,7 @@ final class CredentialProviderCoordinator {
             pendingUnlock = false
             pendingGeneratePasswordPresentation = false
             pendingReadOnlyCancellationMessage = String(localized: "This database is read-only. Open KeeForge to enable editing.")
+            activatePresentationIfPossible()
             return
         }
 
@@ -425,6 +448,7 @@ final class CredentialProviderCoordinator {
         // operate on the same reference.
         activeDatabaseReference = databaseReference
         pendingUnlock = true
+        activatePresentationIfPossible()
     }
 
     @available(iOS 26.2, *)
@@ -448,6 +472,7 @@ final class CredentialProviderCoordinator {
         pendingUnlock = false
         pendingNoEnabledDatabasesPresentation = false
         pendingGeneratePasswordPresentation = true
+        activatePresentationIfPossible()
     }
     #endif
 

--- a/AutoFillExtension/CredentialProviderViewController.swift
+++ b/AutoFillExtension/CredentialProviderViewController.swift
@@ -15,6 +15,7 @@ import UIKit
 @MainActor
 final class CredentialProviderViewController: ASCredentialProviderViewController {
     private lazy var coordinator = CredentialProviderCoordinator(presenter: self)
+    private var hasAppeared = false
 
     // MARK: - Lifecycle
 
@@ -23,9 +24,15 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
         view.backgroundColor = .clear
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        hasAppeared = true
         coordinator.presentationDidBecomeActive()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        hasAppeared = false
     }
 
     // MARK: - Request forwarding
@@ -87,6 +94,10 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 // MARK: - CredentialProviderPresenting
 
 extension CredentialProviderViewController: CredentialProviderPresenting {
+    var isPresentationActive: Bool {
+        hasAppeared
+    }
+
     var isDisplayingContent: Bool {
         presentedViewController != nil
     }

--- a/AutoFillExtension/CredentialProviderViewControllerMac.swift
+++ b/AutoFillExtension/CredentialProviderViewControllerMac.swift
@@ -57,6 +57,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 
     private var hostingController: NSHostingController<AnyView>?
     private var isShowingHostedContent = false
+    private var hasAppeared = false
     /// Guards `cancelActiveRequestIfNeeded()` so a normal completion is never
     /// double-cancelled on window close / view disappearance.
     private var didFinishRequest = false
@@ -76,11 +77,13 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 
     override func viewDidAppear() {
         super.viewDidAppear()
+        hasAppeared = true
         coordinator.presentationDidBecomeActive()
     }
 
     override func viewDidDisappear() {
         super.viewDidDisappear()
+        hasAppeared = false
         // Window close / dismissal has no iOS analogue; make sure a still-pending
         // request tears the vault down instead of leaking an unlocked session.
         cancelActiveRequestIfNeeded()
@@ -130,6 +133,10 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 // MARK: - CredentialProviderPresenting
 
 extension CredentialProviderViewController: CredentialProviderPresenting {
+    var isPresentationActive: Bool {
+        hasAppeared
+    }
+
     var isDisplayingContent: Bool {
         isShowingHostedContent
     }

--- a/AutoFillExtension/README.md
+++ b/AutoFillExtension/README.md
@@ -19,6 +19,7 @@ This target provides password, passkey, one-time-code, and new-credential save/g
 - It reuses `../KeeForge/Models` plus a selected subset of service files declared explicitly in `../project.yml`.
 - The shared model layer links the local `KeeForgeTwofish` package, so Twofish-encrypted databases use the same parser and cipher-preserving writer in the app and extension.
 - Unlock can use stored composite keys plus biometrics for quick AutoFill, or fall back to interactive password entry.
+- Interactive requests are presentation-order independent: the coordinator waits while the shell is off screen and schedules pending UI immediately when a request arrives after the shell has appeared.
 - Password and passkey requests both parse the database locally; the extension does not depend on the main app being open.
 - Expired entries are excluded from proactive identities and automatic password, passkey, and one-time-code fulfillment. They remain available in the interactive picker with an explicit warning and require a manual tap.
 - Save-password requests now prefill a new entry via `../KeeForge/Services/AutoFill/AutoFillSaveCoordinator.swift`, save encrypted bytes through `../KeeForge/Services/Persistence/LocalDatabaseSaver.swift`, and enqueue `../KeeForge/Services/Cloud/PendingUploadQueue.swift` markers for cloud-backed databases before returning success.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ TODO before the first macOS release:
 
 ## Unreleased
 
+- Fix the AutoFill provider remaining on an empty view when an interactive request arrives after its presentation lifecycle callback.
 - Choose which databases appear in AutoFill, get suggestions from all of them at once, and clear AutoFill suggestions in Settings.
 - Switch between databases inside the AutoFill panel.
 - Saving a database now regenerates the file header's random material — master seed, encryption IV, inner stream key, and KDF salt — on every save, matching KeePass 2.x and KeePassXC. KDF cost settings (Argon2 iterations/memory/parallelism, AES-KDF rounds) are preserved, and saved files remain fully compatible with other KeePass clients. Thanks to [Kinglike1337](https://github.com/Kinglike1337) for the contribution.

--- a/KeeForgeTests/CredentialProviderCoordinatorTests.swift
+++ b/KeeForgeTests/CredentialProviderCoordinatorTests.swift
@@ -36,6 +36,33 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
 
     // MARK: - Required cleanup-path tests
 
+    func test_requestPreparedBeforeAppearance_waitsForActivePresentation() throws {
+        let (coordinator, presenter) = makeCoordinator()
+        try seedResolvableDefaultDatabase()
+
+        coordinator.prepareCredentialList(for: [githubServiceIdentifier()])
+
+        XCTAssertNil(presenter.unlockPrompt)
+
+        presenter.isPresentationActive = true
+        coordinator.presentationDidBecomeActive()
+
+        XCTAssertNotNil(presenter.unlockPrompt)
+    }
+
+    func test_requestPreparedAfterAppearance_activatesPresentation() async throws {
+        let (coordinator, presenter) = makeCoordinator()
+        try seedResolvableDefaultDatabase()
+        presenter.isPresentationActive = true
+        let promptPresented = expectation(description: "unlock prompt presented")
+        presenter.onUnlockPromptPresented = { promptPresented.fulfill() }
+
+        coordinator.prepareCredentialList(for: [githubServiceIdentifier()])
+
+        await fulfillment(of: [promptPresented], timeout: 1)
+        XCTAssertNotNil(presenter.unlockPrompt)
+    }
+
     func test_cleanup_runsOnCancel() throws {
         let (coordinator, presenter) = makeCoordinator()
         try seedResolvableDefaultDatabase()
@@ -1310,6 +1337,7 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
 
     @MainActor
     private final class PresenterSpy: CredentialProviderPresenting {
+        var isPresentationActive = false
         var isDisplayingContent = false
 
         struct UnlockPrompt {
@@ -1356,6 +1384,7 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
         var cancelledError: ASExtensionError?
 
         var onUnlockErrorPresented: (() -> Void)?
+        var onUnlockPromptPresented: (() -> Void)?
         var onCompleteRequest: ((ASPasswordCredential) -> Void)?
         /// Fired after every `presentSearchView` recording, mirroring
         /// `onUnlockErrorPresented` — lets async flows (a real unlock task)
@@ -1401,6 +1430,7 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
                 onChooseBiometrics: onChooseBiometrics,
                 onCancel: onCancel
             )
+            onUnlockPromptPresented?()
         }
 
         func presentUnlockError(

--- a/KeeForgeTests/CredentialProviderSaveTests.swift
+++ b/KeeForgeTests/CredentialProviderSaveTests.swift
@@ -464,6 +464,7 @@ final class CredentialProviderSaveTests: XCTestCase {
     /// (the pre-slice-03 `.failed` behavior) sneaks back in.
     @MainActor
     private final class SavePresenterSpy: CredentialProviderPresenting {
+        var isPresentationActive = false
         var isDisplayingContent = false
         private(set) var cancelledErrorCodes: [ASExtensionError.Code] = []
 


### PR DESCRIPTION
# Summary

- Fixes #31.
- Prevent interactive AutoFill requests from remaining pending when AuthenticationServices delivers them after the provider view has appeared.
- Keep the presentation lifecycle shared across the iOS and native macOS shells without changing credential matching or vault logic.

# Changes

- Let presentation shells report whether their view hierarchy is active.
- Schedule pending coordinator presentation after late interactive requests.
- Move the iOS activation hook from `viewWillAppear` to `viewDidAppear`.
- Add focused coverage for request-before-appearance and request-after-appearance ordering.
- Document the lifecycle behavior and add an Unreleased changelog entry.

# Testing

- [x] `xcodebuild test -project KeeForge.xcodeproj -scheme KeeForge -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:KeeForgeTests/CredentialProviderCoordinatorTests -quiet`
- [x] 49 tests passed, 0 failed on iOS 27.0 Simulator after rebasing onto current upstream/main.
- [x] `swiftc -parse` completed for the changed Swift files.
- [x] `git diff --check` passed.

# Checklist

- [x] Updated `CHANGELOG.md` under `## Unreleased`.
- [x] No source files were added, removed, or moved; `xcodegen generate` was not required.
- [x] Updated `AutoFillExtension/README.md` for the lifecycle behavior.
- [x] No user-facing strings were added.
- [x] Kept the shared presenter contract in sync across the iOS and macOS shells.
- [x] Parser, writer, save behavior, and the compatibility matrix are unaffected.
- [x] Accessibility identifiers are unchanged.

