### PR TITLE
fix(clipboard): keep copied values on the pasteboard across an automatic lock

### DIFF
--- a/KeeForge/ViewModels/DatabaseViewModel.swift
+++ b/KeeForge/ViewModels/DatabaseViewModel.swift
@@ -759,11 +759,19 @@ final class DatabaseViewModel {
     func lock(manuallyTriggered: Bool = false) {
         cancelInactivityTimer()
         backgroundEnteredAt = nil
-        // Clear a still-pending secure copy so locking also scrubs the
-        // pasteboard (changeCount-guarded; never clobbers a later user copy).
-        ClipboardService.clearOwnedContents()
         if manuallyTriggered {
             didManuallyLock = true
+            // Scrub a still-pending secure copy when the user explicitly locks
+            // (changeCount-guarded; never clobbers a later user copy).
+            //
+            // Automatic locks deliberately leave the pasteboard alone: entering
+            // the background is exactly the moment the user switches to another
+            // app to paste, so scrubbing there made every copy arrive empty.
+            // The secret stays time-bounded regardless, because
+            // `ClipboardService.copy` already stamps it with the configured
+            // clipboard-clear timeout as an expiration date and keeps it off
+            // Universal Clipboard.
+            ClipboardService.clearOwnedContents()
         }
         beginNewLockCycle()
         state = .locked

--- a/KeeForgeTests/AutoLockTests.swift
+++ b/KeeForgeTests/AutoLockTests.swift
@@ -3,6 +3,9 @@ import XCTest
 #if os(macOS)
 import AppKit
 #endif
+#if os(iOS)
+import UIKit
+#endif
 
 @MainActor
 final class AutoLockTests: XCTestCase {
@@ -150,6 +153,35 @@ final class AutoLockTests: XCTestCase {
             return
         }
     }
+
+#if os(iOS)
+    func testBackgroundLockLeavesCopiedValueOnPasteboard() async throws {
+        SettingsService.autoLockTimeout = .fiveMinutes
+        SettingsService.lockOnBackground = true
+        let vm = try await makeUnlockedViewModel()
+
+        ClipboardService.copy("COPY-PROBE-BACKGROUND")
+        vm.handleSceneDidEnterBackground()
+
+        guard case .locked = vm.state else {
+            XCTFail("Expected .locked after backgrounding with background lock enabled")
+            return
+        }
+        // Backgrounding is exactly when the user switches away to paste, so the
+        // automatic lock must leave the pasteboard intact.
+        XCTAssertEqual(UIPasteboard.general.string, "COPY-PROBE-BACKGROUND")
+    }
+
+    func testManualLockScrubsCopiedValueFromPasteboard() async throws {
+        SettingsService.autoLockTimeout = .fiveMinutes
+        let vm = try await makeUnlockedViewModel()
+
+        ClipboardService.copy("COPY-PROBE-MANUAL")
+        vm.lock(manuallyTriggered: true)
+
+        XCTAssertNotEqual(UIPasteboard.general.string, "COPY-PROBE-MANUAL")
+    }
+#endif
 
     func testBackgroundLockDisabledPreservesVaultAndResumesRemainingTime() async throws {
         SettingsService.autoLockTimeout = .fiveMinutes


### PR DESCRIPTION
Fixes #34.

Copying a password wrote it to the pasteboard, but backgrounding the app locked the database and unconditionally scrubbed the copy — so the value was already gone by the time you switched to another app to paste. It looked like the copy button did nothing.

Backgrounding is exactly the moment a copy is about to be used, so the scrub is now limited to an explicit user lock (`lock(manuallyTriggered: true)`). The clear-on-lock intent from 1.10.3 is preserved for the case it was written for, and the secret stays time-bounded either way: `ClipboardService.copy` already stamps every copy with the configured clipboard-clear timeout as an expiration date and keeps it off Universal Clipboard.

Two tests cover both directions: an automatic background lock leaves the value intact, a manual lock still scrubs it.

Verified locally on an iPhone 17 simulator. Note on the suite: `SettingsServiceTests.testLockOnBackgroundDefaultsToOn` fails, but it fails identically on unmodified `main` (38830d9) — I ran the full suite both with and without this commit and it's the only failure in both, so it's pre-existing and unrelated. Happy to look into that one separately if it's not already known.
