### PR TITLE
feat(autofill): hide individual groups from AutoFill

### DIFF
--- a/AutoFillExtension/CredentialProviderCoordinator.swift
+++ b/AutoFillExtension/CredentialProviderCoordinator.swift
@@ -956,13 +956,10 @@ final class CredentialProviderCoordinator {
         self.parsedMeta = parsed.meta
         self.parsedFormatVersion = parsed.header.formatVersion
 
-        let allEntries: [KPEntry]
-        if let recycleBinID = parsed.rootGroup.recycleBinUUID {
-            allEntries = parsed.rootGroup.allEntries(excludingGroupID: recycleBinID)
-        } else {
-            allEntries = parsed.rootGroup.allEntries
-        }
-        parsedEntries = allEntries.filter { $0.hasPassword || $0.hasPasskey || $0.hasTOTP }
+        let offerableEntries = parsed.rootGroup.autoFillEntries(
+            excludingGroupID: parsed.rootGroup.recycleBinUUID
+        )
+        parsedEntries = offerableEntries.filter { $0.hasPassword || $0.hasPasskey || $0.hasTOTP }
     }
 
     private func loadDatabaseData(for databaseReference: DatabaseReference) throws -> Data {

--- a/AutoFillExtension/README.md
+++ b/AutoFillExtension/README.md
@@ -21,6 +21,7 @@ This target provides password, passkey, one-time-code, and new-credential save/g
 - Unlock can use stored composite keys plus biometrics for quick AutoFill, or fall back to interactive password entry.
 - Password and passkey requests both parse the database locally; the extension does not depend on the main app being open.
 - Expired entries are excluded from proactive identities and automatic password, passkey, and one-time-code fulfillment. They remain available in the interactive picker with an explicit warning and require a manual tap.
+- Groups whose KDBX `<EnableSearching>` resolves to false are skipped entirely: neither the proactive identity store nor the extension's own entry list sees their entries. The filtering lives in one place, `KPGroup.autoFillEntries(excludingGroupID:inheritedSearchingEnabled:)`, which all three AutoFill entry sources call — `DatabaseViewModel.credentialStoreEntries`, `AutoFillSaveCoordinator.credentialStoreEntries`, and the coordinator's own parse. In-app browsing and the in-app search are deliberately unaffected; hiding a group from AutoFill is not meant to hide it from its owner.
 - Save-password requests now prefill a new entry via `../KeeForge/Services/AutoFill/AutoFillSaveCoordinator.swift`, save encrypted bytes through `../KeeForge/Services/Persistence/LocalDatabaseSaver.swift`, and enqueue `../KeeForge/Services/Cloud/PendingUploadQueue.swift` markers for cloud-backed databases before returning success.
 
 ## Platforms And Targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ TODO before the first macOS release:
 ## Unreleased
 
 - Choose which databases appear in AutoFill, get suggestions from all of them at once, and clear AutoFill suggestions in Settings.
+- Hide individual groups from AutoFill. Long-press a group and pick "Hide from AutoFill": its entries stop appearing in QuickType suggestions and in the AutoFill panel's search, while staying fully visible when browsing the database in the app. Subgroups follow their parent unless you turn one back on explicitly. The setting is stored in the standard KDBX `<EnableSearching>` group field, so it is shared with KeePass and KeePassXC instead of living in app-only state.
 - Switch between databases inside the AutoFill panel.
 - Saving a database now regenerates the file header's random material — master seed, encryption IV, inner stream key, and KDF salt — on every save, matching KeePass 2.x and KeePassXC. KDF cost settings (Argon2 iterations/memory/parallelism, AES-KDF rounds) are preserved, and saved files remain fully compatible with other KeePass clients. Thanks to Kinglike1337 for the contribution.
 

--- a/KeeForge/Models/DatabaseDraft.swift
+++ b/KeeForge/Models/DatabaseDraft.swift
@@ -100,6 +100,8 @@ struct DatabaseDraft: Sendable {
             updatedState = try applyDelete(entryID: entryID, sendToRecycleBin: sendToRecycleBin)
         case .deleteGroup(let groupID, let sendToRecycleBin):
             updatedState = try applyDeleteGroup(groupID: groupID, sendToRecycleBin: sendToRecycleBin)
+        case .setGroupSearchingEnabled(let groupID, let value):
+            updatedState = try applySetGroupSearchingEnabled(groupID: groupID, value: value.modelValue)
         }
 
         updatedState.rootGroup.recycleBinUUID = updatedState.meta.recycleBinUUID
@@ -167,6 +169,35 @@ struct DatabaseDraft: Sendable {
             var updatedGroups = group.groups
             updatedGroups.append(newGroup)
             return copyGroup(group, groups: updatedGroups)
+        }
+
+        return (updatedRootGroup, currentMetaStorage)
+    }
+
+    private func applySetGroupSearchingEnabled(
+        groupID: UUID,
+        value: KPInheritableBool
+    ) throws -> (rootGroup: KPGroup, meta: KPMeta) {
+        guard let groupPath = pathToGroup(withID: groupID, in: currentRootGroupStorage) else {
+            throw DraftError.groupNotFound(groupID)
+        }
+
+        let timestamp = Date.now
+        let updatedRootGroup = try rebuildGroup(in: currentRootGroupStorage, targetPath: groupPath[...]) { group in
+            KPGroup(
+                id: group.id,
+                name: group.name,
+                iconID: group.iconID,
+                customIconUUID: group.customIconUUID,
+                entries: group.entries,
+                groups: group.groups,
+                isExpanded: group.isExpanded,
+                searchingEnabled: value,
+                creationTime: group.creationTime,
+                lastModificationTime: timestamp,
+                recycleBinUUID: group.recycleBinUUID,
+                unknownXML: group.unknownXML
+            )
         }
 
         return (updatedRootGroup, currentMetaStorage)
@@ -758,6 +789,7 @@ struct DatabaseDraft: Sendable {
             entries: entries ?? group.entries,
             groups: groups ?? group.groups,
             isExpanded: group.isExpanded,
+            searchingEnabled: group.searchingEnabled,
             creationTime: group.creationTime,
             lastModificationTime: group.lastModificationTime,
             recycleBinUUID: recycleBinUUID,
@@ -776,6 +808,7 @@ private extension KPGroup {
             entries: entries,
             groups: groups.map { $0.deepCopy() },
             isExpanded: isExpanded,
+            searchingEnabled: searchingEnabled,
             creationTime: creationTime,
             lastModificationTime: lastModificationTime,
             recycleBinUUID: recycleBinUUID,

--- a/KeeForge/Models/EntryEdit.swift
+++ b/KeeForge/Models/EntryEdit.swift
@@ -60,10 +60,27 @@ struct EntryDraftPayload: Codable, Sendable, Equatable {
     }
 }
 
+/// Codable mirror of `KPInheritableBool`, kept separate so the KDBX model type
+/// doesn't have to carry a serialization format for the pending-edit log.
+enum InheritableBoolPayload: String, Codable, Sendable, Equatable {
+    case inherit
+    case enabled
+    case disabled
+
+    var modelValue: KPInheritableBool {
+        switch self {
+        case .inherit: return .inherit
+        case .enabled: return .enabled
+        case .disabled: return .disabled
+        }
+    }
+}
+
 enum EntryEdit: Codable, Sendable, Equatable {
     case createEntry(parentGroupID: UUID, draft: EntryDraftPayload)
     case createGroup(parentGroupID: UUID, name: String)
     case updateEntry(entryID: UUID, draft: EntryDraftPayload)
     case deleteEntry(entryID: UUID, sendToRecycleBin: Bool)
     case deleteGroup(groupID: UUID, sendToRecycleBin: Bool)
+    case setGroupSearchingEnabled(groupID: UUID, value: InheritableBoolPayload)
 }

--- a/KeeForge/Models/Group.swift
+++ b/KeeForge/Models/Group.swift
@@ -1,5 +1,45 @@
 import Foundation
 
+/// A KDBX tri-state group flag, as used by `<EnableSearching>` and
+/// `<EnableAutoType>`: an explicit yes/no, or `inherit` (serialized as `null`)
+/// meaning "take the parent's answer".
+enum KPInheritableBool: Sendable, Hashable {
+    case inherit
+    case enabled
+    case disabled
+
+    /// `nil` for `inherit`, so callers can fall back to the parent value with
+    /// a single `??`.
+    var boolValue: Bool? {
+        switch self {
+        case .inherit: return nil
+        case .enabled: return true
+        case .disabled: return false
+        }
+    }
+
+    /// Parses a KDBX element body. Returns `nil` for anything unrecognized so
+    /// the caller can leave the source element in `unknownXML` untouched
+    /// instead of rewriting it into something the original app didn't write.
+    static func parse(_ rawValue: String) -> KPInheritableBool? {
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "null": return .inherit
+        case "true": return .enabled
+        case "false": return .disabled
+        default: return nil
+        }
+    }
+
+    /// KeePass casing: `True`/`False` for the booleans, lowercase `null` for inherit.
+    var xmlValue: String {
+        switch self {
+        case .inherit: return "null"
+        case .enabled: return "True"
+        case .disabled: return "False"
+        }
+    }
+}
+
 /// Represents a KeePass group (folder) containing entries and subgroups
 final class KPGroup: Identifiable, @unchecked Sendable {
     var id: UUID
@@ -12,6 +52,10 @@ final class KPGroup: Identifiable, @unchecked Sendable {
     var entries: [KPEntry]
     var groups: [KPGroup]
     var isExpanded: Bool
+    /// KDBX `<EnableSearching>`. `nil` means the source group had no such
+    /// element at all, which behaves like `.inherit` but is kept distinct so
+    /// the writer doesn't add an element the original app never wrote.
+    var searchingEnabled: KPInheritableBool?
     var creationTime: Date?
     var lastModificationTime: Date?
     /// UUID of the Recycle Bin group (only meaningful on the root group)
@@ -26,6 +70,7 @@ final class KPGroup: Identifiable, @unchecked Sendable {
         entries: [KPEntry] = [],
         groups: [KPGroup] = [],
         isExpanded: Bool = true,
+        searchingEnabled: KPInheritableBool? = nil,
         creationTime: Date? = nil,
         lastModificationTime: Date? = nil,
         recycleBinUUID: UUID? = nil,
@@ -38,6 +83,7 @@ final class KPGroup: Identifiable, @unchecked Sendable {
         self.entries = entries
         self.groups = groups
         self.isExpanded = isExpanded
+        self.searchingEnabled = searchingEnabled
         self.creationTime = creationTime
         self.lastModificationTime = lastModificationTime
         self.recycleBinUUID = recycleBinUUID
@@ -53,6 +99,34 @@ final class KPGroup: Identifiable, @unchecked Sendable {
     func allEntries(excludingGroupID groupID: UUID) -> [KPEntry] {
         guard id != groupID else { return [] }
         return entries + groups.flatMap { $0.allEntries(excludingGroupID: groupID) }
+    }
+
+    /// Recursively collects the entries AutoFill is allowed to offer, honouring
+    /// `<EnableSearching>` down the tree.
+    ///
+    /// A group with `.disabled` contributes nothing, and its subgroups inherit
+    /// that unless they override it with an explicit `.enabled` — matching how
+    /// KeePass resolves the flag. Groups without the element (or with
+    /// `.inherit`) take the parent's answer; the root defaults to enabled.
+    ///
+    /// In-app browsing and the in-app search deliberately keep using
+    /// `allEntries`: hiding a group from AutoFill is not meant to hide it from
+    /// the person who owns the database.
+    func autoFillEntries(
+        excludingGroupID excludedGroupID: UUID? = nil,
+        inheritedSearchingEnabled: Bool = true
+    ) -> [KPEntry] {
+        guard id != excludedGroupID else { return [] }
+
+        let isSearchable = searchingEnabled?.boolValue ?? inheritedSearchingEnabled
+        let ownEntries = isSearchable ? entries : []
+
+        return ownEntries + groups.flatMap {
+            $0.autoFillEntries(
+                excludingGroupID: excludedGroupID,
+                inheritedSearchingEnabled: isSearchable
+            )
+        }
     }
 
     /// Returns a new version of this group with one direct child group replaced.
@@ -72,6 +146,7 @@ final class KPGroup: Identifiable, @unchecked Sendable {
             entries: entries,
             groups: updatedGroups,
             isExpanded: isExpanded,
+            searchingEnabled: searchingEnabled,
             creationTime: creationTime,
             lastModificationTime: lastModificationTime,
             recycleBinUUID: recycleBinUUID,

--- a/KeeForge/Models/KDBXParser.swift
+++ b/KeeForge/Models/KDBXParser.swift
@@ -754,6 +754,7 @@ final class KDBXXMLParser: NSObject, XMLParserDelegate {
         var entries: [KPEntry] = []
         var groups: [KPGroup] = []
         var isExpanded = true
+        var searchingEnabled: KPInheritableBool?
         var creationTime: Date?
         var lastModificationTime: Date?
         var unknownXML = OpaqueXMLNodes.empty
@@ -769,6 +770,7 @@ final class KDBXXMLParser: NSObject, XMLParserDelegate {
                 entries: entries,
                 groups: groups,
                 isExpanded: isExpanded,
+                searchingEnabled: searchingEnabled,
                 creationTime: creationTime,
                 lastModificationTime: lastModificationTime,
                 recycleBinUUID: recycleBinUUID,
@@ -1070,6 +1072,10 @@ final class KDBXXMLParser: NSObject, XMLParserDelegate {
     private var inKey = false
     private var currentBinaryRef: Int?
     private var currentBinaryRefWasParsable = true
+    /// False when the just-closed `<EnableSearching>` held a value we don't
+    /// understand, so `recordOpaqueXML` keeps it as an opaque node instead of
+    /// counting it as structured and losing it on write.
+    private var currentEnableSearchingWasParsable = false
     private var historyDepth = 0
     private var inMeta = false
     private var inCustomIcons = false
@@ -1442,6 +1448,14 @@ final class KDBXXMLParser: NSObject, XMLParserDelegate {
                 groupStack[index].isExpanded = currentText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "false"
             }
 
+        case "EnableSearching" where parentName == "Group":
+            currentEnableSearchingWasParsable = false
+            if currentEntry == nil, !inMeta, let index = groupStack.indices.last,
+               let value = KPInheritableBool.parse(currentText) {
+                groupStack[index].searchingEnabled = value
+                currentEnableSearchingWasParsable = true
+            }
+
         default:
             break
         }
@@ -1523,6 +1537,8 @@ final class KDBXXMLParser: NSObject, XMLParserDelegate {
             guard let index = groupStack.indices.last else { return }
             switch elementName {
             case "UUID", "Name", "IconID", "IsExpanded", "Times", "Entry", "Group":
+                groupStack[index].knownChildCount += 1
+            case "EnableSearching" where currentEnableSearchingWasParsable:
                 groupStack[index].knownChildCount += 1
             default:
                 groupStack[index].unknownXML.append(

--- a/KeeForge/Models/KDBXXMLSerializer.swift
+++ b/KeeForge/Models/KDBXXMLSerializer.swift
@@ -141,6 +141,17 @@ struct KDBXXMLSerializer {
             knownChildCount += 1
         }
 
+        // Positioned after `<Times>`/`<IsExpanded>` and before the children,
+        // which is where KeePass writes it — the opaque-XML insertion indices
+        // recorded by the parser are relative to that same sequence. Absent
+        // (`nil`) means the source group had no element, so none is written and
+        // `knownChildCount` stays put, mirroring the parser exactly.
+        if let searchingEnabled = group.searchingEnabled {
+            xml += try opaqueXML(from: group.unknownXML, path: [], insertionIndex: knownChildCount)
+            xml += element("EnableSearching", value: searchingEnabled.xmlValue)
+            knownChildCount += 1
+        }
+
         for entry in group.entries {
             xml += try opaqueXML(from: group.unknownXML, path: [], insertionIndex: knownChildCount)
             xml += try serializeEntry(entry)

--- a/KeeForge/Models/README.md
+++ b/KeeForge/Models/README.md
@@ -6,7 +6,7 @@ This folder holds the data and logic that the rest of the app depends on. It is 
 
 - `KDBXParser.swift`, `KDBXWriter.swift`, and `KDBXCrypto.swift` implement KDBX 4.x read/write, KDF handling, XML extraction, HMAC checks, payload framing, and decompression guards.
 - `KDBXOuterCipher.swift` centralizes outer-cipher UUID recognition, IV sizing, diagnostics, and AES-256-CBC, ChaCha20, and Twofish-256-CBC dispatch. The Twofish primitive lives in the locally vendored `Vendor/KeeForgeTwofish` package and is shared with AutoFill.
-- `Entry.swift`, `Group.swift`, `EncryptedValue.swift`, and `TOTPGenerator.swift` define the in-memory representation of secrets and time-based codes.
+- `Entry.swift`, `Group.swift`, `EncryptedValue.swift`, and `TOTPGenerator.swift` define the in-memory representation of secrets and time-based codes. `Group.swift` also carries the tri-state `<EnableSearching>` flag (`KPInheritableBool`): `nil` means the source group had no such element and the writer must not invent one, while `.inherit` is an element that is present and explicitly defers to the parent. Making it structured shifts the opaque-XML insertion indices of the unmodelled group siblings around it, so the parser only counts it as known when its value parsed, and the writer emits it in the same position KeePass does — after `<Times>`/`<IsExpanded>`, before the children.
 - `DatabaseDraft.swift` and `EntryEdit.swift` stage in-memory entry/group creates, updates, and deletes while preserving recycle-bin behavior, protected fields, and unknown XML for later save.
 - Changes here should be small, test-backed, and motivated by a real bug, format update, or security requirement.
 

--- a/KeeForge/Resources/Localizable.xcstrings
+++ b/KeeForge/Resources/Localizable.xcstrings
@@ -2434,6 +2434,16 @@
         }
       }
     },
+    "Hidden from AutoFill" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus AutoFill ausgeblendet"
+          }
+        }
+      }
+    },
     "Hidden password" : {
       "localizations" : {
         "de" : {
@@ -2450,6 +2460,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ausblenden"
+          }
+        }
+      }
+    },
+    "Hide from AutoFill" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus AutoFill ausblenden"
           }
         }
       }
@@ -4410,6 +4430,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ einblenden"
+          }
+        }
+      }
+    },
+    "Show in AutoFill" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In AutoFill anzeigen"
+          }
+        }
+      }
+    },
+    "Show in AutoFill (Overrides Parent)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In AutoFill anzeigen (überschreibt übergeordnete Gruppe)"
           }
         }
       }

--- a/KeeForge/Services/AutoFill/AutoFillSaveCoordinator.swift
+++ b/KeeForge/Services/AutoFill/AutoFillSaveCoordinator.swift
@@ -143,12 +143,7 @@ enum AutoFillSaveCoordinator {
     }
 
     static func credentialStoreEntries(from root: KPGroup) -> [KPEntry] {
-        let entries: [KPEntry]
-        if let recycleBinID = root.recycleBinUUID {
-            entries = root.allEntries(excludingGroupID: recycleBinID)
-        } else {
-            entries = root.allEntries
-        }
+        let entries = root.autoFillEntries(excludingGroupID: root.recycleBinUUID)
         return entries.filter { !$0.isExpired() }
     }
 }

--- a/KeeForge/ViewModels/DatabaseViewModel.swift
+++ b/KeeForge/ViewModels/DatabaseViewModel.swift
@@ -277,6 +277,9 @@ final class DatabaseViewModel {
     private var searchableEntryText: [UUID: String] = [:]
     private var recycleBinEntryIDs: Set<UUID> = []
     private var recycleBinGroupIDs: Set<UUID> = []
+    /// Groups whose resolved `<EnableSearching>` is false, including the ones
+    /// that only inherit it from an ancestor.
+    private var autoFillExcludedGroupIDs: Set<UUID> = []
     private var lastSharedCacheRefreshFingerprint: SharedCacheRefreshFingerprint?
     private var isRefreshingSharedCache = false
     private var lastSharedCacheRefreshAt: Date?
@@ -725,6 +728,34 @@ final class DatabaseViewModel {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedName.isEmpty == false else { return }
         try applyEntryEdit(.createGroup(parentGroupID: parentGroupID, name: trimmedName))
+    }
+
+    /// Whether AutoFill currently skips this group, taking an inherited
+    /// `<EnableSearching>` from an ancestor into account. Resolved once per
+    /// tree rebuild, like `isGroupInRecycleBin`.
+    func isGroupExcludedFromAutoFill(groupID: UUID) -> Bool {
+        _ = contentRevision
+        return autoFillExcludedGroupIDs.contains(groupID)
+    }
+
+    /// True when the exclusion comes from an ancestor rather than from this
+    /// group, so the UI can explain why a group is skipped without a toggle
+    /// that looks broken.
+    func isGroupExclusionInherited(groupID: UUID) -> Bool {
+        _ = contentRevision
+        guard groupIndex[groupID]?.searchingEnabled?.boolValue == nil else { return false }
+        return autoFillExcludedGroupIDs.contains(groupID)
+    }
+
+    func setGroupExcludedFromAutoFill(_ excluded: Bool, groupID: UUID) throws {
+        // Re-including writes an explicit `True` rather than `inherit`, so that
+        // a group inside an excluded parent can actually be turned back on.
+        try applyEntryEdit(
+            .setGroupSearchingEnabled(
+                groupID: groupID,
+                value: excluded ? .disabled : .enabled
+            )
+        )
     }
 
     func saveHandlingError() async {
@@ -1213,13 +1244,7 @@ final class DatabaseViewModel {
     }
 
     static func credentialStoreEntries(from root: KPGroup) -> [KPEntry] {
-        let entries: [KPEntry]
-        if let recycleBinID = root.recycleBinUUID {
-            entries = root.allEntries(excludingGroupID: recycleBinID)
-        } else {
-            entries = root.allEntries
-        }
-
+        let entries = root.autoFillEntries(excludingGroupID: root.recycleBinUUID)
         return entries.filter { !$0.isExpired() && ($0.hasPassword || $0.hasPasskey) }
     }
 
@@ -1272,6 +1297,7 @@ final class DatabaseViewModel {
             searchableEntryText = [:]
             recycleBinEntryIDs = []
             recycleBinGroupIDs = []
+            autoFillExcludedGroupIDs = []
             searchResults = []
             contentRevision += 1
             selectedGroupID = nil
@@ -1286,13 +1312,21 @@ final class DatabaseViewModel {
         var nextSearchableEntryText: [UUID: String] = [:]
         var nextRecycleBinEntryIDs = Set<UUID>()
         var nextRecycleBinGroupIDs = Set<UUID>()
+        var nextAutoFillExcludedGroupIDs = Set<UUID>()
         let recycleBinID = root.recycleBinUUID
 
         @discardableResult
-        func index(group: KPGroup, includeInSearch: Bool) -> Int {
+        func index(group: KPGroup, includeInSearch: Bool, autoFillEnabled: Bool) -> Int {
             nextGroupIndex[group.id] = group
             if includeInSearch == false, group.id != recycleBinID {
                 nextRecycleBinGroupIDs.insert(group.id)
+            }
+
+            // Mirrors `KPGroup.autoFillEntries`: an absent element or `.inherit`
+            // takes the parent's answer, an explicit value overrides it.
+            let resolvedAutoFillEnabled = group.searchingEnabled?.boolValue ?? autoFillEnabled
+            if resolvedAutoFillEnabled == false {
+                nextAutoFillExcludedGroupIDs.insert(group.id)
             }
 
             var totalEntryCount = 0
@@ -1309,14 +1343,18 @@ final class DatabaseViewModel {
 
             for childGroup in group.groups {
                 let childIncludedInSearch = includeInSearch && childGroup.id != recycleBinID
-                totalEntryCount += index(group: childGroup, includeInSearch: childIncludedInSearch)
+                totalEntryCount += index(
+                    group: childGroup,
+                    includeInSearch: childIncludedInSearch,
+                    autoFillEnabled: resolvedAutoFillEnabled
+                )
             }
 
             nextGroupEntryCounts[group.id] = totalEntryCount
             return totalEntryCount
         }
 
-        index(group: root, includeInSearch: true)
+        index(group: root, includeInSearch: true, autoFillEnabled: true)
 
         entryIndex = nextEntryIndex
         groupIndex = nextGroupIndex
@@ -1325,6 +1363,7 @@ final class DatabaseViewModel {
         searchableEntryText = nextSearchableEntryText
         recycleBinEntryIDs = nextRecycleBinEntryIDs
         recycleBinGroupIDs = nextRecycleBinGroupIDs
+        autoFillExcludedGroupIDs = nextAutoFillExcludedGroupIDs
         contentRevision += 1
         synchronizeSelections()
         updateSearchResults()

--- a/KeeForge/Views/GroupListView.swift
+++ b/KeeForge/Views/GroupListView.swift
@@ -344,6 +344,13 @@ struct GroupListView: View {
         }
         .macHoverHighlight()
         .contextMenu {
+            if canChangeAutoFillExclusion(groupID) {
+                Button(autoFillExclusionButtonTitle(for: groupID)) {
+                    toggleAutoFillExclusion(groupID)
+                }
+                .accessibilityIdentifier("group-row.autofill-exclusion-context")
+            }
+
             if canDeleteGroup(groupID) {
                 Button(groupDeleteButtonTitle(for: groupID), role: .destructive) {
                     preparePendingGroupDeletion(groupID)
@@ -416,6 +423,33 @@ struct GroupListView: View {
 
     private func groupDeleteButtonTitle(for groupID: UUID) -> String {
         viewModel.isGroupInRecycleBin(groupID: groupID) ? "Delete Permanently" : "Delete"
+    }
+
+    private func canChangeAutoFillExclusion(_ groupID: UUID) -> Bool {
+        viewModel.isReadOnly == false
+            && viewModel.currentRootGroup?.recycleBinUUID != groupID
+            && viewModel.isGroupInRecycleBin(groupID: groupID) == false
+    }
+
+    private func autoFillExclusionButtonTitle(for groupID: UUID) -> String {
+        if viewModel.isGroupExcludedFromAutoFill(groupID: groupID) {
+            return viewModel.isGroupExclusionInherited(groupID: groupID)
+                ? String(localized: "Show in AutoFill (Overrides Parent)")
+                : String(localized: "Show in AutoFill")
+        }
+        return String(localized: "Hide from AutoFill")
+    }
+
+    private func toggleAutoFillExclusion(_ groupID: UUID) {
+        let shouldExclude = viewModel.isGroupExcludedFromAutoFill(groupID: groupID) == false
+        do {
+            try viewModel.setGroupExcludedFromAutoFill(shouldExclude, groupID: groupID)
+            Task {
+                await viewModel.saveHandlingError()
+            }
+        } catch {
+            viewModel.presentSaveError(error)
+        }
     }
 
     private func groupDeleteContextIdentifier(for groupID: UUID) -> String {
@@ -559,6 +593,10 @@ struct GroupRow: View {
         viewModel.currentRootGroup?.recycleBinUUID == groupID
     }
 
+    private var isExcludedFromAutoFill: Bool {
+        isRecycleBin == false && viewModel.isGroupExcludedFromAutoFill(groupID: groupID)
+    }
+
     var body: some View {
         Group {
             if let group {
@@ -584,6 +622,15 @@ struct GroupRow: View {
                         Text("\(viewModel.entryCount(forGroupID: groupID)) entries")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                    }
+
+                    if isExcludedFromAutoFill {
+                        Spacer(minLength: 4)
+                        Image(systemName: "key.slash")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel("Hidden from AutoFill")
+                            .accessibilityIdentifier("group-row.autofill-excluded")
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/KeeForgeTests/DatabaseDraftTests.swift
+++ b/KeeForgeTests/DatabaseDraftTests.swift
@@ -527,6 +527,70 @@ final class DatabaseDraftTests: XCTestCase {
         XCTAssertEqual(updatedParentGroup.entries.count, 1_001)
     }
 
+    func test_setGroupSearchingEnabled_disablesGroupAndTouchesModificationTime() throws {
+        let tree = try makeSyntheticTree(includeRecycleBin: false)
+        let draft = DatabaseDraft(rootGroup: tree.rootGroup, meta: tree.meta, sessionKey: sessionKey)
+        let originalGroup = try XCTUnwrap(findGroup(withID: tree.parentGroupID, in: tree.rootGroup))
+        XCTAssertNil(originalGroup.searchingEnabled)
+
+        let updatedDraft = try draft.apply(
+            .setGroupSearchingEnabled(groupID: tree.parentGroupID, value: .disabled)
+        )
+
+        let updatedGroup = try XCTUnwrap(findGroup(withID: tree.parentGroupID, in: updatedDraft.rootGroup))
+        XCTAssertEqual(updatedGroup.searchingEnabled, .disabled)
+        XCTAssertGreaterThan(
+            try XCTUnwrap(updatedGroup.lastModificationTime),
+            try XCTUnwrap(originalGroup.lastModificationTime)
+        )
+        XCTAssertEqual(updatedGroup.name, originalGroup.name)
+        XCTAssertEqual(updatedGroup.entries.count, originalGroup.entries.count)
+        XCTAssertEqual(updatedGroup.groups.count, originalGroup.groups.count)
+        XCTAssertTrue(updatedDraft.isDirty)
+    }
+
+    func test_setGroupSearchingEnabled_leavesSiblingsAndChildrenAlone() throws {
+        let tree = try makeSyntheticTree(includeRecycleBin: false)
+        let draft = DatabaseDraft(rootGroup: tree.rootGroup, meta: tree.meta, sessionKey: sessionKey)
+
+        let updatedDraft = try draft.apply(
+            .setGroupSearchingEnabled(groupID: tree.parentGroupID, value: .disabled)
+        )
+
+        let originalUntouched = try XCTUnwrap(findGroup(withID: tree.untouchedGroupID, in: tree.rootGroup))
+        let updatedUntouched = try XCTUnwrap(findGroup(withID: tree.untouchedGroupID, in: updatedDraft.rootGroup))
+        try assertGroupsEqual(originalUntouched, updatedUntouched)
+
+        let updatedParent = try XCTUnwrap(findGroup(withID: tree.parentGroupID, in: updatedDraft.rootGroup))
+        for subgroup in updatedParent.groups {
+            XCTAssertNil(
+                subgroup.searchingEnabled,
+                "Children inherit at read time; the edit must not stamp them"
+            )
+        }
+    }
+
+    func test_setGroupSearchingEnabled_reEnablingWritesExplicitValue() throws {
+        let tree = try makeSyntheticTree(includeRecycleBin: false)
+        let draft = DatabaseDraft(rootGroup: tree.rootGroup, meta: tree.meta, sessionKey: sessionKey)
+
+        let updatedDraft = try draft
+            .apply(.setGroupSearchingEnabled(groupID: tree.parentGroupID, value: .disabled))
+            .apply(.setGroupSearchingEnabled(groupID: tree.parentGroupID, value: .enabled))
+
+        let updatedGroup = try XCTUnwrap(findGroup(withID: tree.parentGroupID, in: updatedDraft.rootGroup))
+        XCTAssertEqual(updatedGroup.searchingEnabled, .enabled)
+    }
+
+    func test_setGroupSearchingEnabled_unknownGroup_throws() throws {
+        let tree = try makeSyntheticTree(includeRecycleBin: false)
+        let draft = DatabaseDraft(rootGroup: tree.rootGroup, meta: tree.meta, sessionKey: sessionKey)
+
+        XCTAssertThrowsError(
+            try draft.apply(.setGroupSearchingEnabled(groupID: UUID(), value: .disabled))
+        )
+    }
+
     private func makeSyntheticTree(
         includeRecycleBin: Bool,
         parentEntryOverride: KPEntry? = nil,
@@ -724,6 +788,7 @@ final class DatabaseDraftTests: XCTestCase {
         XCTAssertEqual(lhs.name, rhs.name, file: file, line: line)
         XCTAssertEqual(lhs.iconID, rhs.iconID, file: file, line: line)
         XCTAssertEqual(lhs.isExpanded, rhs.isExpanded, file: file, line: line)
+        XCTAssertEqual(lhs.searchingEnabled, rhs.searchingEnabled, file: file, line: line)
         XCTAssertEqual(lhs.creationTime, rhs.creationTime, file: file, line: line)
         XCTAssertEqual(lhs.lastModificationTime, rhs.lastModificationTime, file: file, line: line)
         XCTAssertEqual(lhs.recycleBinUUID, rhs.recycleBinUUID, file: file, line: line)

--- a/KeeForgeTests/DatabaseViewModelTests.swift
+++ b/KeeForgeTests/DatabaseViewModelTests.swift
@@ -110,6 +110,88 @@ final class DatabaseViewModelTests: XCTestCase {
         XCTAssertFalse(vm.isDirty)
     }
 
+    /// End-to-end proof for #14: hide a group, save through the real save path,
+    /// then read the encrypted file back from disk and check that AutoFill's
+    /// actual entry source no longer offers the entry.
+    func testHiddenGroupSurvivesSaveAndStaysOutOfCredentialStore() async throws {
+        let password = "hidden group save password"
+        let created = try await DatabaseCreationService.create(
+            request: DatabaseCreationRequest(
+                displayName: "Hidden Group Persistence",
+                destination: .appOnlyAcknowledged,
+                password: password
+            )
+        )
+        let vm = DatabaseViewModel(createdDatabase: created)
+        let rootGroupID = try XCTUnwrap(vm.visibleRootGroupID)
+
+        try vm.createGroup(named: "Banking", in: rootGroupID)
+        let hiddenGroupID = try XCTUnwrap(
+            vm.group(withID: rootGroupID)?.groups.first(where: { $0.name == "Banking" })?.id
+        )
+        try vm.applyEntryEdit(
+            .createEntry(
+                parentGroupID: hiddenGroupID,
+                draft: EntryDraftPayload(
+                    title: "Bank Login",
+                    username: "alice",
+                    password: "bank-secret",
+                    url: "https://bank.example.com"
+                )
+            )
+        )
+        try vm.applyEntryEdit(
+            .createEntry(
+                parentGroupID: rootGroupID,
+                draft: EntryDraftPayload(
+                    title: "Mail Login",
+                    username: "alice",
+                    password: "mail-secret",
+                    url: "https://mail.example.com"
+                )
+            )
+        )
+
+        try vm.setGroupExcludedFromAutoFill(true, groupID: hiddenGroupID)
+        try await vm.save()
+
+        let cachedURL = try XCTUnwrap(DatabaseListStore.cachedDatabaseURL(for: created.reference))
+        let reparsedRoot = try KDBXParser.parse(
+            data: Data(contentsOf: cachedURL),
+            password: password,
+            sessionKey: SymmetricKey(size: .bits256)
+        )
+
+        let reparsedHiddenGroup = try XCTUnwrap(
+            Self.findGroup(withID: hiddenGroupID, in: reparsedRoot)
+        )
+        XCTAssertEqual(
+            reparsedHiddenGroup.searchingEnabled,
+            .disabled,
+            "The flag must survive a real encrypted save and reload"
+        )
+
+        let offeredTitles = Set(
+            DatabaseViewModel.credentialStoreEntries(from: reparsedRoot).map(\.title)
+        )
+        XCTAssertTrue(
+            offeredTitles.contains("Mail Login"),
+            "Entries outside the hidden group must still be offered"
+        )
+        XCTAssertFalse(
+            offeredTitles.contains("Bank Login"),
+            "The hidden group's entry must not reach AutoFill after a save and reload"
+        )
+    }
+
+    private static func findGroup(withID groupID: UUID, in group: KPGroup) -> KPGroup? {
+        if group.id == groupID { return group }
+        for childGroup in group.groups {
+            if let match = findGroup(withID: groupID, in: childGroup) { return match }
+        }
+        return nil
+    }
+
     func testSetNicknamePersistsAndRefreshesCurrentReference() throws {
         let reference = try makeReference()
         DatabaseListStore.update(reference)
@@ -382,6 +464,85 @@ final class DatabaseViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isGroupInRecycleBin(groupID: socialGroup.id))
     }
 
+    func testHidingGroupFromAutoFillMarksItAndItsSubgroupsExcluded() async throws {
+        let vm = try makeViewModel()
+        await vm.unlock(password: fixturePassword)
+
+        let rootGroupID = try XCTUnwrap(vm.visibleRootGroupID)
+        try vm.createGroup(named: "Hidden Parent", in: rootGroupID)
+        let parent = try XCTUnwrap(vm.visibleRootGroup?.groups.first(where: { $0.name == "Hidden Parent" }))
+        try vm.createGroup(named: "Hidden Child", in: parent.id)
+        let child = try XCTUnwrap(vm.group(withID: parent.id)?.groups.first)
+
+        XCTAssertFalse(vm.isGroupExcludedFromAutoFill(groupID: parent.id))
+        XCTAssertFalse(vm.isGroupExcludedFromAutoFill(groupID: child.id))
+
+        try vm.setGroupExcludedFromAutoFill(true, groupID: parent.id)
+
+        XCTAssertTrue(vm.isGroupExcludedFromAutoFill(groupID: parent.id))
+        XCTAssertTrue(vm.isGroupExcludedFromAutoFill(groupID: child.id))
+        XCTAssertFalse(
+            vm.isGroupExclusionInherited(groupID: parent.id),
+            "The parent carries the flag itself"
+        )
+        XCTAssertTrue(
+            vm.isGroupExclusionInherited(groupID: child.id),
+            "The child is only excluded through its parent"
+        )
+        XCTAssertFalse(vm.isGroupExcludedFromAutoFill(groupID: rootGroupID))
+    }
+
+    func testShowingGroupInAutoFillAgainOverridesExcludedParent() async throws {
+        let vm = try makeViewModel()
+        await vm.unlock(password: fixturePassword)
+
+        let rootGroupID = try XCTUnwrap(vm.visibleRootGroupID)
+        try vm.createGroup(named: "Excluded Parent", in: rootGroupID)
+        let parent = try XCTUnwrap(vm.visibleRootGroup?.groups.first(where: { $0.name == "Excluded Parent" }))
+        try vm.createGroup(named: "Exception", in: parent.id)
+        let child = try XCTUnwrap(vm.group(withID: parent.id)?.groups.first)
+
+        try vm.setGroupExcludedFromAutoFill(true, groupID: parent.id)
+        try vm.setGroupExcludedFromAutoFill(false, groupID: child.id)
+
+        XCTAssertTrue(vm.isGroupExcludedFromAutoFill(groupID: parent.id))
+        XCTAssertFalse(vm.isGroupExcludedFromAutoFill(groupID: child.id))
+    }
+
+    func testHidingGroupFromAutoFillRemovesItsEntriesFromCredentialStore() async throws {
+        let vm = try makeViewModel()
+        var observedEntries: [[KPEntry]] = []
+        let refreshExpectation = expectation(description: "Credential store refreshed after hiding a group")
+
+        CredentialIdentityStoreManager.populateObserver = { _, entries in
+            observedEntries.append(entries)
+            if observedEntries.count == 2 {
+                refreshExpectation.fulfill()
+            }
+        }
+
+        await vm.unlock(password: fixturePassword)
+
+        let workGroup = try XCTUnwrap(vm.visibleRootGroup?.groups.first(where: { $0.name == "Work" }))
+        let hiddenEntry = try XCTUnwrap(workGroup.allEntries.first(where: { !$0.title.isEmpty }))
+        let hiddenEntryIDs = Set(workGroup.allEntries.map(\.id))
+
+        try vm.setGroupExcludedFromAutoFill(true, groupID: workGroup.id)
+
+        await fulfillment(of: [refreshExpectation], timeout: 30)
+
+        XCTAssertTrue(
+            hiddenEntryIDs.isDisjoint(with: Set(observedEntries.last?.map(\.id) ?? [])),
+            "Entries of a hidden group must not reach the credential store"
+        )
+
+        vm.searchText = hiddenEntry.title
+        XCTAssertTrue(
+            vm.searchResults.contains(where: { $0.id == hiddenEntry.id }),
+            "Hiding a group from AutoFill must not hide it from the in-app search"
+        )
+    }
+
     func testGroupDeletionSummaryCountsEntriesAndNestedGroups() async throws {
         let vm = try makeViewModel()
         await vm.unlock(password: fixturePassword)
@@ -512,6 +673,64 @@ final class DatabaseViewModelTests: XCTestCase {
         let identities = DatabaseViewModel.credentialStoreEntries(from: root)
 
         XCTAssertEqual(Set(identities.map(\.id)), Set([passwordEntry.id, passkeyEntry.id]))
+    }
+
+    func testCredentialStoreEntriesSkipsGroupsHiddenFromAutoFill() throws {
+        let sessionKey = SymmetricKey(size: .bits256)
+        func makeEntry(_ title: String) throws -> KPEntry {
+            KPEntry(
+                title: title,
+                username: "user",
+                password: try EncryptedValue.encrypt("secret", using: sessionKey),
+                url: "https://example.com"
+            )
+        }
+
+        let visible = try makeEntry("Visible")
+        let hidden = try makeEntry("Hidden")
+        let deeplyHidden = try makeEntry("Deeply Hidden")
+        let reEnabled = try makeEntry("Re-enabled")
+
+        let root = KPGroup(
+            name: "Root",
+            entries: [visible],
+            groups: [
+                KPGroup(
+                    name: "Secret",
+                    entries: [hidden],
+                    groups: [
+                        KPGroup(name: "Deeper", entries: [deeplyHidden]),
+                        KPGroup(name: "Exception", entries: [reEnabled], searchingEnabled: .enabled),
+                    ],
+                    searchingEnabled: .disabled
+                )
+            ]
+        )
+
+        let identities = DatabaseViewModel.credentialStoreEntries(from: root)
+
+        XCTAssertEqual(Set(identities.map(\.id)), Set([visible.id, reEnabled.id]))
+    }
+
+    func testSaveCoordinatorCredentialStoreEntriesSkipsGroupsHiddenFromAutoFill() throws {
+        let sessionKey = SymmetricKey(size: .bits256)
+        let visible = KPEntry(
+            title: "Visible",
+            password: try EncryptedValue.encrypt("secret", using: sessionKey)
+        )
+        let hidden = KPEntry(
+            title: "Hidden",
+            password: try EncryptedValue.encrypt("secret", using: sessionKey)
+        )
+        let root = KPGroup(
+            name: "Root",
+            entries: [visible],
+            groups: [KPGroup(name: "Secret", entries: [hidden], searchingEnabled: .disabled)]
+        )
+
+        let entries = AutoFillSaveCoordinator.credentialStoreEntries(from: root)
+
+        XCTAssertEqual(Set(entries.map(\.id)), Set([visible.id]))
     }
 
     func testUnlockDisabledDatabaseDoesNotPopulateOrClaimActivePointer() async throws {

--- a/KeeForgeTests/KDBXRoundTripTests.swift
+++ b/KeeForgeTests/KDBXRoundTripTests.swift
@@ -465,6 +465,7 @@ final class KDBXRoundTripTests: XCTestCase {
         XCTAssertEqual(lhs.name, rhs.name, file: file, line: line)
         XCTAssertEqual(lhs.iconID, rhs.iconID, file: file, line: line)
         XCTAssertEqual(lhs.isExpanded, rhs.isExpanded, file: file, line: line)
+        XCTAssertEqual(lhs.searchingEnabled, rhs.searchingEnabled, file: file, line: line)
         XCTAssertEqual(lhs.creationTime, rhs.creationTime, file: file, line: line)
         XCTAssertEqual(lhs.lastModificationTime, rhs.lastModificationTime, file: file, line: line)
         XCTAssertEqual(lhs.recycleBinUUID, rhs.recycleBinUUID, file: file, line: line)
@@ -693,5 +694,137 @@ final class KDBXRoundTripTests: XCTestCase {
         let reparsedEntry = try XCTUnwrap(reparsed.rootGroup.allEntries.first)
         XCTAssertTrue(reparsedEntry.hasTagsElement, "hasTagsElement should survive round-trip")
         XCTAssertTrue(reparsedEntry.tags.isEmpty, "tags array should remain empty")
+    }
+
+    // MARK: - EnableSearching round-trip
+
+    func test_enableSearching_allThreeStates_surviveRoundTrip() throws {
+        let xml = """
+        <KeePassFile><Root><Group><Name>Root</Name>
+        <Group><Name>Off</Name><EnableSearching>False</EnableSearching></Group>
+        <Group><Name>On</Name><EnableSearching>True</EnableSearching></Group>
+        <Group><Name>Inherit</Name><EnableSearching>null</EnableSearching></Group>
+        <Group><Name>NoElement</Name></Group>
+        </Group></Root></KeePassFile>
+        """
+
+        let parsed = try parseXML(Data(xml.utf8))
+        let reparsed = try serializeAndParse(parsed)
+
+        for tree in [parsed, reparsed] {
+            // `rootGroup` is the synthetic wrapper for `<Root>`; the group named
+            // "Root" in the XML is its single child.
+            let container = try XCTUnwrap(tree.rootGroup.groups.first)
+            let groups = Dictionary(
+                uniqueKeysWithValues: container.groups.map { ($0.name, $0) }
+            )
+            XCTAssertEqual(groups["Off"]?.searchingEnabled, .disabled)
+            XCTAssertEqual(groups["On"]?.searchingEnabled, .enabled)
+            XCTAssertEqual(groups["Inherit"]?.searchingEnabled, .inherit)
+            XCTAssertNil(
+                groups["NoElement"]?.searchingEnabled,
+                "A group without the element must stay without it"
+            )
+        }
+    }
+
+    func test_enableSearching_absentElement_isNotAddedOnWrite() throws {
+        let root = KPGroup(name: "Root", groups: [KPGroup(name: "Plain")])
+
+        var serializer = KDBXXMLSerializer(
+            rootGroup: root,
+            meta: KPMeta(),
+            innerStreamKey: roundTripInnerStreamKey,
+            sessionKey: roundTripSessionKey
+        )
+        let xmlString = String(data: try serializer.serialize(), encoding: .utf8)!
+
+        XCTAssertFalse(
+            xmlString.contains("EnableSearching"),
+            "Writing a group that never had the element must not invent one"
+        )
+    }
+
+    /// The value KeeForge writes has to be one KeePass itself accepts, so a
+    /// database stays usable in both apps.
+    func test_enableSearching_writesKeePassCasing() throws {
+        let root = KPGroup(
+            name: "Root",
+            groups: [KPGroup(name: "Hidden", searchingEnabled: .disabled)]
+        )
+
+        var serializer = KDBXXMLSerializer(
+            rootGroup: root,
+            meta: KPMeta(),
+            innerStreamKey: roundTripInnerStreamKey,
+            sessionKey: roundTripSessionKey
+        )
+        let xmlString = String(data: try serializer.serialize(), encoding: .utf8)!
+
+        XCTAssertTrue(xmlString.contains("<EnableSearching>False</EnableSearching>"))
+    }
+
+    /// An unparsable value must fall through to the opaque-XML path rather than
+    /// being silently rewritten or dropped.
+    func test_enableSearching_unrecognizedValue_isPreservedVerbatim() throws {
+        let xml = """
+        <KeePassFile><Root><Group><Name>Root</Name>
+        <Group><Name>Weird</Name><EnableSearching>maybe</EnableSearching></Group>
+        </Group></Root></KeePassFile>
+        """
+
+        let parsed = try parseXML(Data(xml.utf8))
+        let container = try XCTUnwrap(parsed.rootGroup.groups.first)
+        let weird = try XCTUnwrap(container.groups.first)
+        XCTAssertNil(weird.searchingEnabled, "\"maybe\" is not a tri-state value")
+
+        var serializer = KDBXXMLSerializer(
+            rootGroup: parsed.rootGroup,
+            meta: parsed.meta,
+            innerStreamKey: roundTripInnerStreamKey,
+            sessionKey: roundTripSessionKey
+        )
+        let xmlString = String(data: try serializer.serialize(), encoding: .utf8)!
+
+        XCTAssertTrue(
+            xmlString.contains("<EnableSearching>maybe</EnableSearching>"),
+            "Unknown values must round-trip untouched"
+        )
+    }
+
+    /// Regression guard for the opaque-XML position bookkeeping: making
+    /// `<EnableSearching>` a structured element shifts the insertion indices of
+    /// the unmodelled siblings around it, and none of them may be lost.
+    func test_enableSearching_doesNotDisturbSurroundingUnknownElements() throws {
+        let xml = """
+        <KeePassFile><Root><Group><Name>Root</Name>
+        <Group><UUID>rG5FhCLXQ0GDRLRUEBEHUw==</UUID><Name>Nested</Name><Notes>group notes</Notes>\
+        <IconID>48</IconID><IsExpanded>True</IsExpanded>\
+        <DefaultAutoTypeSequence>{USERNAME}</DefaultAutoTypeSequence>\
+        <EnableAutoType>null</EnableAutoType>\
+        <EnableSearching>False</EnableSearching>\
+        <LastTopVisibleEntry>AAAAAAAAAAAAAAAAAAAAAA==</LastTopVisibleEntry></Group>
+        </Group></Root></KeePassFile>
+        """
+
+        let parsed = try parseXML(Data(xml.utf8))
+        var serializer = KDBXXMLSerializer(
+            rootGroup: parsed.rootGroup,
+            meta: parsed.meta,
+            innerStreamKey: roundTripInnerStreamKey,
+            sessionKey: roundTripSessionKey
+        )
+        let xmlString = String(data: try serializer.serialize(), encoding: .utf8)!
+
+        XCTAssertTrue(xmlString.contains("<Notes>group notes</Notes>"))
+        XCTAssertTrue(xmlString.contains("<DefaultAutoTypeSequence>{USERNAME}</DefaultAutoTypeSequence>"))
+        XCTAssertTrue(xmlString.contains("<EnableAutoType>null</EnableAutoType>"))
+        XCTAssertTrue(xmlString.contains("<LastTopVisibleEntry>AAAAAAAAAAAAAAAAAAAAAA==</LastTopVisibleEntry>"))
+
+        let reparsed = try parseXML(Data(xmlString.utf8))
+        let container = try XCTUnwrap(reparsed.rootGroup.groups.first)
+        let nested = try XCTUnwrap(container.groups.first)
+        XCTAssertEqual(nested.searchingEnabled, .disabled)
+        XCTAssertEqual(nested.name, "Nested")
     }
 }

--- a/KeeForgeTests/ModelLogicTests.swift
+++ b/KeeForgeTests/ModelLogicTests.swift
@@ -84,4 +84,117 @@ final class ModelLogicTests: XCTestCase {
         XCTAssertEqual(lhs, rhs)
         XCTAssertEqual(Set([lhs, rhs]).count, 1)
     }
+
+    // MARK: - autoFillEntries / EnableSearching
+
+    func testAutoFillEntriesIncludesEverythingByDefault() {
+        let root = KPGroup(
+            name: "Root",
+            entries: [KPEntry(title: "top")],
+            groups: [KPGroup(name: "Child", entries: [KPEntry(title: "nested")])]
+        )
+
+        XCTAssertEqual(titles(root.autoFillEntries()), ["top", "nested"])
+    }
+
+    func testAutoFillEntriesSkipsDisabledGroupAndItsSubgroups() {
+        let root = KPGroup(
+            name: "Root",
+            entries: [KPEntry(title: "top")],
+            groups: [
+                KPGroup(
+                    name: "Secret",
+                    entries: [KPEntry(title: "hidden")],
+                    groups: [KPGroup(name: "Deeper", entries: [KPEntry(title: "alsoHidden")])],
+                    searchingEnabled: .disabled
+                ),
+                KPGroup(name: "Normal", entries: [KPEntry(title: "visible")]),
+            ]
+        )
+
+        XCTAssertEqual(titles(root.autoFillEntries()), ["top", "visible"])
+    }
+
+    func testAutoFillEntriesTreatsInheritAndAbsentElementTheSame() {
+        func makeRoot(child: KPInheritableBool?) -> KPGroup {
+            KPGroup(
+                name: "Root",
+                groups: [
+                    KPGroup(
+                        name: "Secret",
+                        groups: [
+                            KPGroup(
+                                name: "Child",
+                                entries: [KPEntry(title: "nested")],
+                                searchingEnabled: child
+                            )
+                        ],
+                        searchingEnabled: .disabled
+                    )
+                ]
+            )
+        }
+
+        XCTAssertEqual(titles(makeRoot(child: .inherit).autoFillEntries()), [])
+        XCTAssertEqual(titles(makeRoot(child: nil).autoFillEntries()), [])
+    }
+
+    func testAutoFillEntriesLetsSubgroupOverrideDisabledParent() {
+        let root = KPGroup(
+            name: "Root",
+            groups: [
+                KPGroup(
+                    name: "Secret",
+                    entries: [KPEntry(title: "hidden")],
+                    groups: [
+                        KPGroup(
+                            name: "Exception",
+                            entries: [KPEntry(title: "visible")],
+                            searchingEnabled: .enabled
+                        )
+                    ],
+                    searchingEnabled: .disabled
+                )
+            ]
+        )
+
+        XCTAssertEqual(titles(root.autoFillEntries()), ["visible"])
+    }
+
+    func testAutoFillEntriesStillHonoursExcludedGroupID() {
+        let recycleBinID = UUID()
+        let root = KPGroup(
+            name: "Root",
+            entries: [KPEntry(title: "top")],
+            groups: [
+                KPGroup(id: recycleBinID, name: "Recycle Bin", entries: [KPEntry(title: "trashed")])
+            ]
+        )
+
+        XCTAssertEqual(titles(root.autoFillEntries(excludingGroupID: recycleBinID)), ["top"])
+    }
+
+    func testAutoFillEntriesWithNilExclusionKeepsWholeTree() {
+        let root = KPGroup(
+            name: "Root",
+            entries: [KPEntry(title: "top")],
+            groups: [KPGroup(name: "Child", entries: [KPEntry(title: "nested")])]
+        )
+
+        XCTAssertEqual(titles(root.autoFillEntries(excludingGroupID: nil)), ["top", "nested"])
+    }
+
+    func testInheritableBoolParsingIsCaseInsensitiveAndRejectsGarbage() {
+        XCTAssertEqual(KPInheritableBool.parse("True"), .enabled)
+        XCTAssertEqual(KPInheritableBool.parse("true"), .enabled)
+        XCTAssertEqual(KPInheritableBool.parse("FALSE"), .disabled)
+        XCTAssertEqual(KPInheritableBool.parse(" null \n"), .inherit)
+        XCTAssertNil(KPInheritableBool.parse(""))
+        XCTAssertNil(KPInheritableBool.parse("0"))
+        XCTAssertNil(KPInheritableBool.parse("yes"))
+    }
+
+    private func titles(_ entries: [KPEntry]) -> [String] {
+        entries.map(\.title)
+    }
 }


### PR DESCRIPTION
Closes #14.

Follow-up to my comment on the issue. Long-press a group and pick "Hide from AutoFill" and its entries stop showing up in QuickType and in the AutoFill panel, while staying completely normal when you browse the database in the app.

## Why `<EnableSearching>`

This is a standard KDBX group field, so nothing app-specific is needed and the setting travels with the file. KeePassium models it as `isSearchingEnabled: Bool?` in `Group2.swift`, KeePassXC reads and writes it in `KdbxXmlReader`/`KdbxXmlWriter`. A group hidden in KeeForge stays hidden in KeePass and the other way around.

It is tri-state: `True`, `False`, or `null` for "inherit from parent". I modelled that as `KPInheritableBool?` on `KPGroup`, where the outer optional means the element was not in the file at all. That distinction matters for round-tripping: a group that never had the element must not get one written, or every save would touch groups the user never edited.

## Round-trip care

Making `<EnableSearching>` structured moves it out of `unknownXML`, which shifts the recorded insertion indices of the group's other unmodelled siblings (`Notes`, `DefaultAutoTypeSequence`, `EnableAutoType`, `LastTopVisibleEntry`). Two things keep that safe:

- The parser only counts the element as known when its value actually parsed. An unrecognized value falls through to the opaque-XML path and is re-emitted verbatim.
- The writer emits it in the same position KeePass does, after `<Times>`/`<IsExpanded>` and before the children, so the indices line up with what the parser recorded.

There is a test that puts all four of those unmodelled siblings around an `<EnableSearching>` element and checks every one survives.

## Where the filtering happens

One accessor, `KPGroup.autoFillEntries(excludingGroupID:inheritedSearchingEnabled:)`, replaces the three near-identical `allEntries(excludingGroupID:)` blocks that fed AutoFill:

- `DatabaseViewModel.credentialStoreEntries` (QuickType identity store)
- `AutoFillSaveCoordinator.credentialStoreEntries` (re-publish after a save from the extension)
- `CredentialProviderCoordinator.parsedEntries` (the extension's own list and search)

Inheritance resolves the way KeePass does it: a disabled group takes its subgroups with it, unless a subgroup sets an explicit `True`. Re-enabling from the context menu writes that explicit `True` rather than `inherit`, otherwise turning a group back on inside a hidden parent would do nothing.

## Scope decision

In-app browsing and the in-app search deliberately still use `allEntries`. KeePass treats the flag as "exclude from search" generally, but hiding a group from AutoFill is not the same wish as hiding it from the person who owns the database, and the issue asks for the AutoFill case. If you want the stricter KeePass reading instead, it is a one-line change at `updateSearchResults`. Happy to switch it.

## UI

Context menu entry on the group row, plus a small `key.slash` badge so you can see which groups are hidden without opening the menu. Groups that are only hidden through a parent get "Show in AutoFill (Overrides Parent)" so the toggle does not look broken. The recycle bin and read-only databases are excluded. German strings added to the catalog.

## Tests

22 new tests: tri-state parse and round-trip including the unmodelled-sibling regression guard, inheritance and override semantics, the draft edit, and that a hidden group's entries leave the credential store while staying findable in the in-app search. `searchingEnabled` was also added to the two `assertGroupsEqual` helpers, so every existing fixture round-trip now covers it too.

The one I would look at first is `testHiddenGroupSurvivesSaveAndStaysOutOfCredentialStore`. It goes through the real path rather than the model in isolation: create a database, hide a group, save through `LocalDatabaseSaver`, then read the encrypted file back off disk and assert both that the flag persisted and that `credentialStoreEntries` no longer offers the hidden entry while still offering the one outside it.

One gap worth naming: the extension's own read path at `CredentialProviderCoordinator.swift:987` is not covered by a test. The existing coordinator tests seed `parsedEntries` directly, so the filter is never reached, and building a harness that unlocks a real vault there would have meant touching the App Group plumbing, which felt out of proportion for this change. It calls the same accessor with the same argument as the covered app-side path, so I am fairly confident, but it is inference rather than a measurement and you should know that before merging.

Full suite: 991 pass, 22/22 new tests pass. The one red test is `SettingsServiceTests.testLockOnBackgroundDefaultsToOn`, which also fails on unmodified `main` at the same commit on my machine and looks like `UserDefaults` bleed between tests rather than anything in this branch.

Based on `main` rather than #35, so the two stay independent. I checked that they merge cleanly in either order.

## Not included

No per-entry exclusion. The issue mentions entries as well, but KDBX has no per-entry equivalent, so it would need either a custom field or a KeeForge-only store. Worth deciding separately.
