### PR TITLE
refactor(kdbx): tidy history-trim follow-ups from the #50 review

### DIFF
--- a/KeeForge/Models/DatabaseDraft.swift
+++ b/KeeForge/Models/DatabaseDraft.swift
@@ -567,11 +567,12 @@ struct DatabaseDraft: Sendable {
         // versions of a KeePass-authored file, whose `<History>` is oldest-first
         // where this app prepends, and reordering the array would rewrite a
         // foreign file's bytes on every save.
+        let byRecency = recencyOrderedIndices(of: history)
         var survivors = Set(history.indices)
 
         let maxItems = meta.resolvedHistoryMaxItems
         if maxItems >= 0, history.count > maxItems {
-            survivors = Set(recencyOrderedIndices(of: history).prefix(maxItems))
+            survivors = Set(byRecency.prefix(maxItems))
         }
 
         let maxSize = meta.resolvedHistoryMaxSize
@@ -579,7 +580,7 @@ struct DatabaseDraft: Sendable {
             var retained: Set<Int> = []
             var sizeSoFar: Int64 = 0
 
-            for index in recencyOrderedIndices(of: history) where survivors.contains(index) {
+            for index in byRecency where survivors.contains(index) {
                 let entrySize = estimatedHistorySize(for: history[index])
                 if sizeSoFar + entrySize > maxSize {
                     break

--- a/KeeForgeTests/DatabaseDraftTests.swift
+++ b/KeeForgeTests/DatabaseDraftTests.swift
@@ -271,7 +271,8 @@ final class DatabaseDraftTests: XCTestCase {
     /// longer spends its budget on the versions it should have dropped.
     func test_updateEntry_maxSizeSpendsTheBudgetOnTheNewestVersions() throws {
         let padding = String(repeating: "x", count: 1_000)
-        // Each padded version costs 256 + title + 1000 + 8 ("history-" password is 8).
+        // Each padded version costs 256 + title + 1000 + 7 ("history" password),
+        // so the budget covers the snapshot and one padded version, not two.
         let updatedEntry = try applyTitleEdit(
             toEntryWithHistory: [
                 historyVersion("v1-oldest", at: 700, notes: padding),
@@ -286,46 +287,6 @@ final class DatabaseDraftTests: XCTestCase {
             ["Original Entry", "v3-newest"],
             "the budget must go to the newest versions, not the ones stored first"
         )
-    }
-
-    private func historyVersion(
-        _ title: String,
-        at seconds: TimeInterval?,
-        notes: String = ""
-    ) throws -> KPEntry {
-        KPEntry(
-            id: UUID(),
-            title: title,
-            password: try EncryptedValue.encrypt("history", using: sessionKey),
-            notes: notes,
-            lastModificationTime: seconds.map { Date(timeIntervalSince1970: $0) }
-        )
-    }
-
-    /// Edits the synthetic tree's entry so its pre-edit state ("Original Entry") is
-    /// pushed onto `history` and the trim runs.
-    private func applyTitleEdit(
-        toEntryWithHistory history: [KPEntry],
-        meta: KPMeta
-    ) throws -> KPEntry {
-        let tree = try makeSyntheticTree(includeRecycleBin: false)
-        let treeWithHistory = try makeSyntheticTree(
-            includeRecycleBin: false,
-            parentEntryOverride: withUpdatedEntry(tree.parentEntry, history: history),
-            metaOverride: meta
-        )
-        var payload = try makeDraftPayload(from: treeWithHistory.parentEntry)
-        payload.title = "Updated Title"
-
-        let draft = DatabaseDraft(
-            rootGroup: treeWithHistory.rootGroup,
-            meta: treeWithHistory.meta,
-            sessionKey: sessionKey
-        )
-        let updatedDraft = try draft.apply(
-            .updateEntry(entryID: treeWithHistory.parentEntry.id, draft: payload)
-        )
-        return try XCTUnwrap(findEntry(withID: treeWithHistory.parentEntry.id, in: updatedDraft.rootGroup))
     }
 
     func test_updateEntry_trimsHistoryToConfiguredMaxSize_oldestFirst() throws {
@@ -1116,6 +1077,46 @@ final class DatabaseDraftTests: XCTestCase {
             untouchedGroupID: untouchedGroupID,
             recycleBinGroupID: recycleBinGroupID
         )
+    }
+
+    private func historyVersion(
+        _ title: String,
+        at seconds: TimeInterval?,
+        notes: String = ""
+    ) throws -> KPEntry {
+        KPEntry(
+            id: UUID(),
+            title: title,
+            password: try EncryptedValue.encrypt("history", using: sessionKey),
+            notes: notes,
+            lastModificationTime: seconds.map { Date(timeIntervalSince1970: $0) }
+        )
+    }
+
+    /// Edits the synthetic tree's entry so its pre-edit state ("Original Entry") is
+    /// pushed onto `history` and the trim runs.
+    private func applyTitleEdit(
+        toEntryWithHistory history: [KPEntry],
+        meta: KPMeta
+    ) throws -> KPEntry {
+        let tree = try makeSyntheticTree(includeRecycleBin: false)
+        let treeWithHistory = try makeSyntheticTree(
+            includeRecycleBin: false,
+            parentEntryOverride: withUpdatedEntry(tree.parentEntry, history: history),
+            metaOverride: meta
+        )
+        var payload = try makeDraftPayload(from: treeWithHistory.parentEntry)
+        payload.title = "Updated Title"
+
+        let draft = DatabaseDraft(
+            rootGroup: treeWithHistory.rootGroup,
+            meta: treeWithHistory.meta,
+            sessionKey: sessionKey
+        )
+        let updatedDraft = try draft.apply(
+            .updateEntry(entryID: treeWithHistory.parentEntry.id, draft: payload)
+        )
+        return try XCTUnwrap(findEntry(withID: treeWithHistory.parentEntry.id, in: updatedDraft.rootGroup))
     }
 
     /// Entry whose TOTP arrived as a legacy `otpauth://` URI in the `otp`


### PR DESCRIPTION
# Summary

Follow-up to the review of #50 (merged in 70ee549). Three cleanups that were called out as non-blocking nits at review time. No behavior change — the trimming logic, the caps, and every assertion are unchanged.

# Changes

- **Compute the recency order once.** `trimmedHistory` called `recencyOrderedIndices(of:)` separately for the `HistoryMaxItems` and `HistoryMaxSize` passes. It is a pure function of `history`, which is a `let` that does not mutate between the two uses, so both passes now share a single `byRecency` local.
- **Fix a stale cost comment** in `test_updateEntry_maxSizeSpendsTheBudgetOnTheNewestVersions`. It named a password (`"history-"`, 8 bytes) that the `historyVersion` helper does not use (`"history"`, 7), and now states what the arithmetic is there to demonstrate. Re-derived to confirm the test is not fragile: the snapshot costs ~372 bytes (256 + the synthetic entry's title/username/url/notes/tags/password + the sealed passkey — `cloneForHistory` clears only `history`, so the passkey is retained), + `v3-newest` at 1272 = 1644, and `v2` at 1265 would reach 2909 against the 2800 budget, so the loop breaks. `["Original Entry", "v3-newest"]` holds with margin either way.
- **Move `historyVersion` and `applyTitleEdit`** from between test methods down to the private-helper section beside `makeSyntheticTree` / `makeLegacyOTPEntry`, matching how the rest of the file keeps its fixtures. Pure move — each helper is declared exactly once and nothing outside `DatabaseDraftTests` references them.

# Testing

- [ ] **Not run locally — this branch was authored in a Linux container with no Xcode toolchain**, so the changes are verified by inspection only and CI is the first real execution. The slice to run is:
  ```
  xcodebuild test -project KeeForge.xcodeproj -scheme KeeForge \
    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
    -only-testing:KeeForgeTests/DatabaseDraftTests -quiet
  ```
- `KeeForgeMacTests` compiles the `KeeForgeTests` folder, so the moved helpers must build there too — covered by the macOS test job.

# Checklist

- [x] Updated `CHANGELOG.md` under `## Unreleased` (feature/bug-fix changes) — n/a, no user-visible change; the #50 entry already describes the fix.
- [x] Ran `xcodegen generate` after adding/removing/moving source files — n/a, no files added, removed, or moved; `project.yml` untouched, so both AutoFill allow-lists stay byte-identical.
- [x] Updated the nearest folder-local `README.md` if the folder's map changed — n/a, `KeeForge/Models/README.md` already carries the selection-vs-order rule from #50 and stays accurate.
- [x] Localized new UI strings in all shipped locales (`en`, `de`) and ran `LocalizationTests` — n/a, no new strings.
- [x] Kept AutoFill extension target membership/imports in sync for shared code — `DatabaseDraft.swift` compiles into `KeeForgeAutoFill`; no new imports and no target-membership change.
- [x] Updated `KDBXCompatibilityTests` if parser/writer/save behavior changed — n/a, no behavior change.
- [x] Preserved accessibility identifiers or updated the affected UI tests — n/a, no UI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AFpVDvQYPBt2VG5BC8Wum)_