### PR TITLE
fix(autofill): preserve OTP subdomain context

### DIFF
--- a/AutoFillExtension/CredentialProviderCoordinator.swift
+++ b/AutoFillExtension/CredentialProviderCoordinator.swift
@@ -1666,8 +1666,10 @@ final class CredentialProviderCoordinator {
             return
         }
 
-        let matches = CredentialMatcher.matchedEntries(from: totpEntries, for: serviceIdentifiers)
-        let strictMatches = CredentialMatcher.strictMatchedEntries(from: totpEntries, for: serviceIdentifiers)
+        let strictMatches = CredentialMatcher.orderedStrictMatchedEntries(from: totpEntries, for: serviceIdentifiers)
+        let matches = strictMatches.isEmpty
+            ? CredentialMatcher.matchedEntries(from: totpEntries, for: serviceIdentifiers)
+            : strictMatches
 
         // Auto-complete without a picker only when the single candidate matched
         // on host, not on a weaker URL/title substring signal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ TODO before the first macOS release:
 
 ### Fixes
 
+- OTP AutoFill identities now preserve each explicit web host, including meaningful subdomains, instead of collapsing entries to their registrable domain.
 - The gear button inside an open database now opens the same settings screen as the database list's "Database Details". It had been missing the file format, size, encryption and key-derivation rows, the "Include in AutoFill" toggle, and the cloud account and sync status.
 - The "Read-only" toggle in Database Details no longer offers to make a KDBX 3.1 database editable. KeeForge keeps that legacy format read-only, so turning the toggle off changed nothing; it is now disabled and says why.
 - Edited entry titles and usernames now refresh immediately in entry lists, search results, and title sorting without reopening the database.

--- a/KeeForge/Services/AutoFill/CredentialIdentityStoreManager.swift
+++ b/KeeForge/Services/AutoFill/CredentialIdentityStoreManager.swift
@@ -475,7 +475,7 @@ enum CredentialIdentityStoreManager: Sendable {
 
             var otcCount = 0
             if #available(iOS 18.0, macOS 15.0, *) {
-                let otcIds = eligibleEntries.compactMap { oneTimeCodeIdentity(for: $0, in: databaseID) }
+                let otcIds = eligibleEntries.flatMap { oneTimeCodeIdentities(for: $0, in: databaseID) }
                 databaseIdentities.append(contentsOf: otcIds)
                 otcCount = otcIds.count
             }
@@ -571,9 +571,6 @@ enum CredentialIdentityStoreManager: Sendable {
     /// rebuild the identities byte-identical to what was published —
     /// including the database-tagged record identifier — and every caller of
     /// this API has the open database at hand, so the id costs nothing.
-    /// One-time-code identities are intentionally not rebuilt here (matching
-    /// today's behavior); they are cleaned up by the owning database's next
-    /// full-store refresh.
     static func removeIdentities(for entries: [KPEntry], in databaseID: UUID) {
         enqueueMutation { store in
             guard await store.isEnabled() else { return }
@@ -583,6 +580,11 @@ enum CredentialIdentityStoreManager: Sendable {
 
             var identitiesToRemove: [any ASCredentialIdentity] = passwordIds
             identitiesToRemove.append(contentsOf: passkeyIds)
+            if #available(iOS 18.0, macOS 15.0, *) {
+                identitiesToRemove.append(contentsOf: entries.flatMap {
+                    oneTimeCodeIdentities(for: $0, in: databaseID)
+                })
+            }
             guard !identitiesToRemove.isEmpty else { return }
 
             do {
@@ -735,21 +737,28 @@ enum CredentialIdentityStoreManager: Sendable {
 
     @available(iOS 18.0, macOS 15.0, *)
     static func oneTimeCodeIdentity(for entry: KPEntry, in databaseID: UUID) -> ASOneTimeCodeCredentialIdentity? {
-        guard entry.hasTOTP else { return nil }
+        oneTimeCodeIdentities(for: entry, in: databaseID).first
+    }
+
+    @available(iOS 18.0, macOS 15.0, *)
+    static func oneTimeCodeIdentities(for entry: KPEntry, in databaseID: UUID) -> [ASOneTimeCodeCredentialIdentity] {
+        guard entry.hasTOTP else { return [] }
 
         let allURLs = [entry.url] + entry.additionalURLs
-        let domain = allURLs.compactMap(domainFromURLString).first
-        guard let domain else { return nil }
+        var seenHosts = Set<String>()
+        let hosts = allURLs.compactMap(otpHostFromURLString).filter { seenHosts.insert($0).inserted }
 
         let label = entry.title.isEmpty ? entry.username : entry.title
-        guard !label.isEmpty else { return nil }
+        guard !label.isEmpty else { return [] }
 
-        let serviceIdentifier = ASCredentialServiceIdentifier(identifier: domain, type: .domain)
-        return ASOneTimeCodeCredentialIdentity(
-            serviceIdentifier: serviceIdentifier,
-            label: label,
-            recordIdentifier: CredentialRecordIdentifier(databaseID: databaseID, entryID: entry.id).encoded
-        )
+        let recordIdentifier = CredentialRecordIdentifier(databaseID: databaseID, entryID: entry.id).encoded
+        return hosts.map { host in
+            ASOneTimeCodeCredentialIdentity(
+                serviceIdentifier: ASCredentialServiceIdentifier(identifier: host, type: .domain),
+                label: label,
+                recordIdentifier: recordIdentifier
+            )
+        }
     }
 
     // MARK: - Passkey identities
@@ -819,6 +828,33 @@ enum CredentialIdentityStoreManager: Sendable {
 
         guard let host else { return nil }
         return registeredDomain(from: host)
+    }
+
+    private static func otpHostFromURLString(_ urlString: String) -> String? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let parsedURL = URL(string: trimmed)
+        let url: URL?
+        if parsedURL?.scheme == nil {
+            url = URL(string: "https://\(trimmed)")
+        } else {
+            url = parsedURL
+        }
+
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host,
+              let validatedDomain = registeredDomain(from: host)
+        else { return nil }
+
+        let normalizedHost = host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        let withoutWWW = normalizedHost.hasPrefix("www.")
+            ? String(normalizedHost.dropFirst(4))
+            : normalizedHost
+        guard !withoutWWW.isEmpty, validatedDomain == registeredDomain(from: withoutWWW) else { return nil }
+        return withoutWWW
     }
 
     // MARK: - Registered domain extraction

--- a/KeeForge/Services/AutoFill/CredentialMatcher.swift
+++ b/KeeForge/Services/AutoFill/CredentialMatcher.swift
@@ -10,6 +10,36 @@ enum CredentialMatcher {
         matchedEntries(from: entries, for: identifiers, strict: true)
     }
 
+    /// Uses Apple's service-identifier order: the first identifier is the most
+    /// specific one, so a match there wins over broader identifiers.
+    static func orderedStrictMatchedEntries(
+        from entries: [KPEntry],
+        for identifiers: [ASCredentialServiceIdentifier]
+    ) -> [KPEntry] {
+        for identifier in identifiers {
+            guard let term = searchTerm(for: identifier) else { continue }
+
+            let exactMatches = entries.filter { entry in
+                guard !entry.isExpired() else { return false }
+                return ([entry.url] + entry.additionalURLs).contains { urlString in
+                    hostFromURLString(urlString) == term
+                }
+            }
+            let exactMatchIDs = Set(exactMatches.map(\.id))
+            let childMatches = entries.filter { entry in
+                guard !exactMatchIDs.contains(entry.id) else { return false }
+                guard !entry.isExpired() else { return false }
+                return ([entry.url] + entry.additionalURLs).contains { urlString in
+                    guard let host = hostFromURLString(urlString) else { return false }
+                    return host != term && host.hasSuffix(".\(term)")
+                }
+            }
+            let matches = exactMatches + childMatches
+            if !matches.isEmpty { return matches }
+        }
+        return []
+    }
+
     /// Broad matches for interactive pickers: host matches plus URL and
     /// title substring matches. Substring matches can surface wrong-origin
     /// entries (`mybank.com` for a `bank.com` request), so results must

--- a/KeeForgeTests/CredentialIdentityStoreManagerTests.swift
+++ b/KeeForgeTests/CredentialIdentityStoreManagerTests.swift
@@ -368,7 +368,83 @@ final class CredentialIdentityStoreManagerTests: XCTestCase {
         let identity = CredentialIdentityStoreManager.oneTimeCodeIdentity(for: entry, in: someDatabaseID)
 
         XCTAssertNotNil(identity)
-        XCTAssertEqual(identity?.serviceIdentifier.identifier, "example.com")
+        XCTAssertEqual(identity?.serviceIdentifier.identifier, "backup.example.com")
+    }
+
+    func testOTCIdentitiesPreserveExplicitSubdomain() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time code identities require iOS 18 / macOS 15")
+        }
+
+        let entry = makeEntry(
+            title: "VT",
+            url: "https://vt.example.com/login",
+            username: "user",
+            hasPassword: false,
+            hasTOTP: true
+        )
+
+        let identities = CredentialIdentityStoreManager.oneTimeCodeIdentities(for: entry, in: someDatabaseID)
+
+        XCTAssertEqual(identities.map { $0.serviceIdentifier.identifier }, ["vt.example.com"])
+    }
+
+    func testOTCIdentitiesAcceptBareWebHost() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time code identities require iOS 18 / macOS 15")
+        }
+
+        let entry = makeEntry(
+            title: "Bare Host",
+            url: "vt.example.com/login",
+            username: "user",
+            hasPassword: false,
+            hasTOTP: true
+        )
+
+        let identities = CredentialIdentityStoreManager.oneTimeCodeIdentities(for: entry, in: someDatabaseID)
+
+        XCTAssertEqual(identities.map { $0.serviceIdentifier.identifier }, ["vt.example.com"])
+    }
+
+    func testOTCIdentitiesUseDistinctExplicitWebHostsInURLOrder() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time code identities require iOS 18 / macOS 15")
+        }
+
+        let entry = makeEntry(
+            title: "Multiple",
+            url: "https://vt.example.com/login",
+            username: "user",
+            hasPassword: false,
+            hasTOTP: true,
+            customFields: [
+                "KP2A_URL_1": "https://example.com/otp",
+                "KP2A_URL_2": "https://VT.EXAMPLE.COM/duplicate",
+            ]
+        )
+
+        let identities = CredentialIdentityStoreManager.oneTimeCodeIdentities(for: entry, in: someDatabaseID)
+
+        XCTAssertEqual(identities.map { $0.serviceIdentifier.identifier }, ["vt.example.com", "example.com"])
+        XCTAssertEqual(Set(identities.map(\.recordIdentifier)).count, 1)
+    }
+
+    func testOTCIdentitiesSkipOtpauthAndNonWebURLs() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time code identities require iOS 18 / macOS 15")
+        }
+
+        let entry = makeEntry(
+            title: "URI Only",
+            url: "otpauth://totp/example:user?secret=JBSWY3DPEHPK3PXP",
+            username: "user",
+            hasPassword: false,
+            hasTOTP: true,
+            customFields: ["KP2A_URL_1": "ftp://example.com/otp"]
+        )
+
+        XCTAssertTrue(CredentialIdentityStoreManager.oneTimeCodeIdentities(for: entry, in: someDatabaseID).isEmpty)
     }
 
     // MARK: - hasTOTP
@@ -582,6 +658,48 @@ final class CredentialIdentityStoreManagerTests: XCTestCase {
             storedRecordIdentifiers(fake),
             [CredentialRecordIdentifier(databaseID: databaseID, entryID: live.id).encoded]
         )
+    }
+
+    func testPopulateRefreshRemovesOldOTCDomainByRecordIdentifier() async throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time code identities require iOS 18 / macOS 15")
+        }
+
+        let fake = installFake()
+        let databaseID = UUID()
+        let otherDatabaseID = UUID()
+        let entry = makeEntry(
+            title: "Subdomain",
+            url: "https://vt.example.com/login",
+            username: "user",
+            hasPassword: false,
+            hasTOTP: true
+        )
+        let oldEntry = makeEntry(
+            id: entry.id,
+            title: "Root",
+            url: "https://example.com/login",
+            username: "user",
+            hasPassword: false,
+            hasTOTP: true
+        )
+        fake.stored = CredentialIdentityStoreManager.oneTimeCodeIdentities(for: oldEntry, in: databaseID)
+            + CredentialIdentityStoreManager.passwordIdentities(
+                for: makeEntry(title: "Other", url: "https://other.example", username: "other", hasPassword: true),
+                in: otherDatabaseID
+            )
+
+        let mutation = expectMutations(2, on: fake)
+        CredentialIdentityStoreManager.populate(with: [entry], for: databaseID)
+        await fulfillment(of: [mutation], timeout: 1)
+
+        XCTAssertEqual(fake.calls, ["removeCredentialIdentities", "saveCredentialIdentities"])
+        XCTAssertTrue(fake.stored.contains {
+            ($0 as? ASOneTimeCodeCredentialIdentity)?.serviceIdentifier.identifier == "vt.example.com"
+        })
+        XCTAssertFalse(fake.stored.contains {
+            ($0 as? ASOneTimeCodeCredentialIdentity)?.serviceIdentifier.identifier == "example.com"
+        })
     }
 
     func testPopulateWithNoEligibleEntriesEmptiesStore() async {

--- a/KeeForgeTests/CredentialMatcherTests.swift
+++ b/KeeForgeTests/CredentialMatcherTests.swift
@@ -177,6 +177,16 @@ final class CredentialMatcherTests: XCTestCase {
         XCTAssertEqual(CredentialMatcher.strictMatchedEntries(from: entries, for: ids).count, 1)
     }
 
+    func testOrderedStrictMatchesPreferExactHostBeforeChildSubdomain() {
+        let child = makeEntry(title: "Child", url: "https://login.vt.example.com", username: "u", password: "p")
+        let exact = makeEntry(title: "Exact", url: "https://vt.example.com", username: "u", password: "p")
+        let ids = [ASCredentialServiceIdentifier(identifier: "vt.example.com", type: .domain)]
+
+        let matches = CredentialMatcher.orderedStrictMatchedEntries(from: [child, exact], for: ids)
+
+        XCTAssertEqual(matches.map(\.title), ["Exact", "Child"])
+    }
+
     func testStrictDoesNotMatchTermInURLPath() {
         // A term appearing in the path of an unrelated host must not strictly match.
         let entries = [makeEntry(title: "Evil", url: "https://evil.example/bank.com/login", username: "u", password: "p")]

--- a/KeeForgeTests/CredentialProviderCoordinatorTests.swift
+++ b/KeeForgeTests/CredentialProviderCoordinatorTests.swift
@@ -384,6 +384,37 @@ final class CredentialProviderCoordinatorTests: XCTestCase {
         assertCleanedUp(coordinator)
     }
 
+    func test_otcList_prefersMostSpecificOrderedServiceIdentifier() throws {
+        guard #available(iOS 18.0, macOS 15.0, *) else {
+            throw XCTSkip("One-time-code requests require iOS 18 / macOS 15")
+        }
+
+        let (coordinator, presenter) = makeCoordinator()
+        let sessionKey = SymmetricKey(size: .bits256)
+        let specific = KPEntry(
+            title: "Specific",
+            url: "https://vt.example.com/login",
+            totpConfig: TOTPConfig(secret: try EncryptedValue.encrypt("JBSWY3DPEHPK3PXP", using: sessionKey))
+        )
+        let root = KPEntry(
+            title: "Root",
+            url: "https://example.com/login",
+            totpConfig: TOTPConfig(secret: try EncryptedValue.encrypt("JBSWY3DPEHPK3PXP", using: sessionKey))
+        )
+
+        coordinator.prepareOneTimeCodeCredentialList(for: [
+            ASCredentialServiceIdentifier(identifier: "vt.example.com", type: .domain),
+            ASCredentialServiceIdentifier(identifier: "example.com", type: .domain),
+        ])
+        seedUnlockedVaultState(coordinator, entries: [root, specific], sessionKey: sessionKey)
+
+        coordinator.presentOTCMatchesOrFinish()
+
+        XCTAssertNotNil(presenter.completedOneTimeCode, "The more specific ordered host should win")
+        XCTAssertNil(presenter.searchView)
+        assertCleanedUp(coordinator)
+    }
+
     func test_otcList_multipleMatches_presentsPickerAndCompletesOnSelection() throws {
         guard #available(iOS 18.0, macOS 15.0, *) else {
             throw XCTSkip("One-time-code requests require iOS 18 / macOS 15")


### PR DESCRIPTION
# Summary

Closes #70

Preserve OTP AutoFill specificity for subdomains while keeping exact-host suggestions ahead of broader matches.

# Changes

- Publish web URL identities using the exact host instead of collapsing subdomains.
- Match OTP identities deterministically, preferring an exact host before child subdomains.
- Preserve existing password AutoFill behavior and filter unsupported URL schemes.
- Add focused regression coverage for identity publication, matching, and provider coordination.

# Testing

- [x] 188 focused unit tests passed with 0 failures:
  - `CredentialIdentityStoreManagerTests` (89)
  - `CredentialProviderCoordinatorTests` (62)
  - `CredentialMatcherTests` (37)
- [x] `KeeForgeMac` build completed with code signing disabled.
- [x] `git diff --check` passed.
- [x] Receipt-driven review pre-commit validation returned `allow`.

# Checklist

- [x] Updated `CHANGELOG.md` under `## Unreleased`.
- [x] No source files were added, removed, or moved, so XcodeGen regeneration was not required.
- [x] No folder map changed, so no folder-local README update was required.
- [x] No new UI strings were introduced, so localization catalogs were unchanged.
- [x] AutoFill extension target membership and extension-safe imports remain in sync.
- [x] No parser, writer, save-path, or KDBX compatibility behavior changed.
- [x] No accessibility identifiers changed.
